### PR TITLE
chore(nix): add flake support for build, run, and devShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,48 @@ cargo build --release
 
 ---
 
+### ❄️ Nix (Flakes)
+
+A `flake.nix` is provided for [Nix](https://nixos.org/) users. Requires flakes
+enabled (`experimental-features = nix-command flakes` in `~/.config/nix/nix.conf`).
+
+**Run without installing:**
+
+```bash
+nix run github:timhartmann7/omnyssh
+nix run github:timhartmann7/omnyssh -- --theme dracula
+```
+
+**Build a local checkout:**
+
+```bash
+git clone https://github.com/timhartmann7/omnyssh.git
+cd omnyssh
+nix build              # binary at ./result/bin/omny
+./result/bin/omny --version
+```
+
+**Install into your user profile:**
+
+```bash
+nix profile install github:timhartmann7/omnyssh
+```
+
+**Develop with a pinned toolchain:**
+
+```bash
+nix develop            # drops you into a shell with rustc, cargo, clippy,
+                       # rustfmt, rust-analyzer, and all build inputs ready
+cargo build
+```
+
+The flake exposes `packages.default` (the `omny` binary plus man page),
+`apps.default` (for `nix run`), and `devShells.default`. It evaluates
+cleanly across `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, and
+`aarch64-darwin`.
+
+---
+
 ## Quick Start
 
 1. **Install OmnySSH** (see above)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "OmnySSH — TUI SSH dashboard & server manager";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+
+        omnyssh = pkgs.rustPlatform.buildRustPackage {
+          pname = cargoToml.package.name;
+          version = cargoToml.package.version;
+
+          src = self;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          nativeBuildInputs = [ pkgs.pkg-config pkgs.installShellFiles ];
+
+          postInstall = ''
+            installManPage doc/omny.1
+          '';
+
+          meta = with pkgs.lib; {
+            description = cargoToml.package.description;
+            homepage = cargoToml.package.repository;
+            license = licenses.asl20;
+            mainProgram = "omny";
+          };
+        };
+      in
+      {
+        packages = {
+          default = omnyssh;
+          omnyssh = omnyssh;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${omnyssh}/bin/omny";
+          meta = omnyssh.meta;
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ omnyssh ];
+          packages = with pkgs; [
+            rustc
+            cargo
+            rustfmt
+            clippy
+            rust-analyzer
+          ];
+
+          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+        };
+      });
+}


### PR DESCRIPTION
## Problem

There is no first-class way to build or run OmnySSH from a Nix-based system.
Users on NixOS, nix-darwin, or with Nix installed on other distros currently
have to either install Rust system-wide or fall back to `cargo install
omnyssh`, neither of which fits a reproducible Nix workflow.

## Solution

Add a `flake.nix` that exposes:

- `packages.default` (and `packages.omnyssh`) — builds the `omny` binary via
  `rustPlatform.buildRustPackage`, using `Cargo.lock` for hash pinning, and
  installs the generated `doc/omny.1` man page via `installManPage`.
- `apps.default` — entry point for `nix run`, with `meta` populated from the
  package so `nix flake check` is warning-free.
- `devShells.default` — `rustc`, `cargo`, `rustfmt`, `clippy`, `rust-analyzer`,
  plus all build inputs from the package, with `RUST_SRC_PATH` set for LSP
  std-library navigation.

Implementation notes:

- `pname` / `version` / `description` / `homepage` are read from `Cargo.toml`
  via `builtins.fromTOML`, so they stay in sync without duplication.
- No Apple SDK frameworks are referenced — the legacy
  `darwin.apple_sdk.frameworks.*` paths were removed in recent nixpkgs and
  modern stdenv on Darwin already exposes what `russh` needs.
- `nixpkgs` is pinned to `nixos-unstable`; `flake-utils` is used only for
  `eachDefaultSystem` to avoid hand-rolling the system list.

`README.md` gets a new **❄️ Nix (Flakes)** section under Installation, after
`From Source`, covering `nix run`, `nix build`, `nix profile install`, and
`nix develop`.

## Test plan

- [x] `nix flake check --all-systems` — passes for `x86_64-linux`,
      `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin` with no warnings.
- [x] `nix build .` on `x86_64-linux` — produces `./result/bin/omny`.
- [x] `nix run .` and `nix run . -- --help` — binary launches.
- [x] `nix develop` — drops into a shell where `cargo build` and
      `cargo clippy -- -D warnings` succeed.
- [x] `cargo test && cargo clippy -- -D warnings && cargo fmt --check` —
      unaffected; no Rust source changes.
- [x] `README.md` renders correctly on GitHub.

## Checklist

- [x] All tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy -- -D warnings`)
- [x] Code is formatted (`cargo fmt`)
- [x] Relevant tests added — N/A, packaging-only change
- [ ] CHANGELOG entry added — happy to add one under "Unreleased" if you
      prefer; left out for now since this is build-tooling, not a user-visible
      runtime change
- [x] README updated

## Files changed

- `flake.nix` — new
- `flake.lock` — new (generated, pins `nixpkgs` and `flake-utils`)
- `README.md` — new "❄️ Nix (Flakes)" section under Installation
