### PR TITLE
Add in-app update checker (v1.0.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,14 @@ jobs:
       - name: List artifacts
         run: ls -lh artifacts/
 
+      # Generate SHA256SUMS with bare filenames so the in-app updater can
+      # verify a downloaded archive against its checksum.
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum omny-* > SHA256SUMS
+          cat SHA256SUMS
+
       # Извлекаем блок текущего релиза из CHANGELOG.md
       # (от первого "## [X.Y.Z]" до следующего "## [")
       - name: Extract changelog entry
@@ -169,3 +177,4 @@ jobs:
             artifacts/omny-x86_64-apple-darwin.tar.gz
             artifacts/omny-aarch64-apple-darwin.tar.gz
             artifacts/omny-x86_64-pc-windows-msvc.zip
+            artifacts/SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-# Срабатывает только при пуше тега вида v1.0.0, v1.2.3 и т.д.
+# Triggered only by pushing a tag like v1.0.0, v1.2.3, etc.
 on:
   push:
     tags:
@@ -11,7 +11,7 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  # ── 1. Проверка качества (те же чеки что и в CI) ───────────────────────────
+  # ── 1. Quality checks (same as the CI workflow) ────────────────────────────
   ci:
     name: CI checks
     runs-on: ubuntu-latest
@@ -34,17 +34,17 @@ jobs:
       - run: cargo clippy -- -D warnings
       - run: cargo fmt --check
 
-  # ── 2. Сборка релизных бинарников ──────────────────────────────────────────
+  # ── 2. Build release binaries ──────────────────────────────────────────────
   #
-  # Четыре платформы собираются параллельно и независимо.
-  # Каждый job загружает свой архив как GitHub Actions artifact,
-  # который финальный job "publish" потом прикрепляет к Release.
+  # The four platforms are built in parallel and independently.
+  # Each job uploads its archive as a GitHub Actions artifact,
+  # which the final "publish" job then attaches to the Release.
   #
-  # Маппинг runner → target:
-  #   ubuntu-latest  → x86_64-unknown-linux-gnu  (нативно)
-  #   macos-latest   → x86_64-apple-darwin        (ARM runner, кросс-компиляция)
-  #   macos-latest   → aarch64-apple-darwin        (Apple Silicon runner, нативно)
-  #   windows-latest → x86_64-pc-windows-msvc      (нативно)
+  # runner → target mapping:
+  #   ubuntu-latest  → x86_64-unknown-linux-gnu  (native)
+  #   macos-latest   → x86_64-apple-darwin       (ARM runner, cross-compiled)
+  #   macos-latest   → aarch64-apple-darwin      (Apple Silicon runner, native)
+  #   windows-latest → x86_64-pc-windows-msvc    (native)
   build:
     name: Build · ${{ matrix.target }}
     needs: ci
@@ -90,11 +90,11 @@ jobs:
           restore-keys: |
             ${{ matrix.target }}-cargo-
 
-      # Сборка релизного бинарника (оптимизированный, stripped)
+      # Build the release binary (optimized, stripped)
       - name: Build release binary
         run: cargo build --release --locked --target ${{ matrix.target }}
 
-      # Упаковка для Unix (tar.gz)
+      # Package for Unix (tar.gz)
       - name: Package (Unix)
         if: runner.os != 'Windows'
         run: |
@@ -102,7 +102,7 @@ jobs:
           tar czf "${{ matrix.archive }}" ${{ matrix.binary }}
           mv "${{ matrix.archive }}" "${{ github.workspace }}/"
 
-      # Упаковка для Windows (zip)
+      # Package for Windows (zip)
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -110,7 +110,7 @@ jobs:
           cd target/${{ matrix.target }}/release
           Compress-Archive -Path ${{ matrix.binary }} -DestinationPath "${{ github.workspace }}/${{ matrix.archive }}"
 
-      # Загружаем архив как артефакт — publish job его скачает
+      # Upload the archive as an artifact — the publish job downloads it
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -119,25 +119,25 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # ── 3. Создание GitHub Release и прикрепление бинарников ───────────────────
+  # ── 3. Create the GitHub Release and attach the binaries ───────────────────
   publish:
     name: Publish GitHub Release
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # нужно для создания Release
+      contents: write   # required to create the Release
 
     steps:
       - uses: actions/checkout@v4
 
-      # Скачиваем все 4 архива из предыдущих jobs
+      # Download all four archives from the previous jobs
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           merge-multiple: true
 
-      # Проверяем что все файлы на месте
+      # Make sure all files are present
       - name: List artifacts
         run: ls -lh artifacts/
 
@@ -156,14 +156,14 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"   # strip the leading "v" from the tag
           BODY=$(awk "/^## ${VERSION} /{found=1; next} found && (/^## /||/^---\$/){exit} found{print}" CHANGELOG.md)
-          # Передаём многострочный текст через GITHUB_OUTPUT
+          # Pass the multi-line text through GITHUB_OUTPUT
           {
             echo 'body<<CHANGELOG_EOF'
             echo "$BODY"
             echo 'CHANGELOG_EOF'
           } >> "$GITHUB_OUTPUT"
 
-      # Создаём Release и прикрепляем все бинарники одним шагом
+      # Create the Release and attach all binaries in one step
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,13 +149,13 @@ jobs:
           sha256sum omny-* > SHA256SUMS
           cat SHA256SUMS
 
-      # Извлекаем блок текущего релиза из CHANGELOG.md
-      # (от первого "## [X.Y.Z]" до следующего "## [")
+      # Extract the current release block from CHANGELOG.md: from the
+      # "## X.Y.Z" heading down to the next "## " heading or "---" rule.
       - name: Extract changelog entry
         id: changelog
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"   # убираем "v" из тега
-          BODY=$(awk "/^## \[${VERSION}\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md)
+          VERSION="${GITHUB_REF_NAME#v}"   # strip the leading "v" from the tag
+          BODY=$(awk "/^## ${VERSION} /{found=1; next} found && (/^## /||/^---\$/){exit} found{print}" CHANGELOG.md)
           # Передаём многострочный текст через GITHUB_OUTPUT
           {
             echo 'body<<CHANGELOG_EOF'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## 1.0.2 — 2026-05-15
+
+### Features
+- **Automatic update checks**: On startup OmnySSH checks GitHub Releases for a newer version and shows a popup when one is available. You can install the update, skip that version, or disable checks entirely. Failed or offline checks are silent and never delay startup.
+- **In-app self-update**: For manual / `install.sh` installs on Linux and macOS, an update can be downloaded and installed from within the app — the release archive is verified against its SHA-256 checksum before the binary is replaced. Homebrew, Cargo, and Nix installs instead show the matching upgrade command.
+
+### Other
+- Release archives are now published alongside a `SHA256SUMS` checksum file.
+
+---
+
 ## 1.0.1 — 2026-04-22
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +170,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -290,6 +302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,7 +432,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
@@ -487,7 +505,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -515,7 +533,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -527,7 +545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -681,6 +699,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,7 +747,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -746,7 +775,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -769,12 +798,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -793,6 +828,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -828,6 +873,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -942,6 +996,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,7 +1039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1025,6 +1106,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,10 +1228,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1062,6 +1350,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1095,6 +1385,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1139,6 +1435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1468,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1502,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1240,7 +1560,7 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "libc",
 ]
 
@@ -1282,7 +1602,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1296,7 +1616,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1358,13 +1678,19 @@ dependencies = [
  "clap_mangen",
  "crossterm",
  "dirs",
+ "flate2",
  "nucleo",
  "portable-pty",
  "ratatui",
+ "reqwest",
  "russh",
  "russh-keys",
  "russh-sftp",
+ "self-replace",
+ "semver",
  "serde",
+ "sha2",
+ "tar",
  "thiserror 2.0.18",
  "tokio",
  "toml",
@@ -1432,7 +1758,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
 ]
 
@@ -1445,7 +1771,7 @@ dependencies = [
  "bytes",
  "delegate",
  "futures",
- "rand",
+ "rand 0.8.6",
  "thiserror 1.0.69",
  "tokio",
  "windows",
@@ -1500,6 +1826,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,7 +1871,7 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "pkcs5",
- "rand_core",
+ "rand_core 0.6.4",
  "spki",
 ]
 
@@ -1588,6 +1920,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,6 +1941,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1621,6 +1972,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,14 +2036,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1647,7 +2075,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1656,7 +2094,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1715,7 +2162,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -1738,6 +2185,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,6 +2230,20 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1766,7 +2265,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
  "signature",
  "spki",
@@ -1804,8 +2303,8 @@ dependencies = [
  "p384",
  "p521",
  "poly1305",
- "rand",
- "rand_core",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "russh-cryptovec",
  "russh-keys",
  "russh-sftp",
@@ -1849,7 +2348,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "futures",
- "getrandom",
+ "getrandom 0.2.17",
  "hmac",
  "home",
  "inout",
@@ -1864,8 +2363,8 @@ dependencies = [
  "pkcs1",
  "pkcs5",
  "pkcs8",
- "rand",
- "rand_core",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "rsa",
  "russh-cryptovec",
  "russh-util",
@@ -1913,6 +2412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,8 +2435,56 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1993,6 +2546,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,11 +2593,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -2139,7 +2728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2226,7 +2815,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand_core",
+ "rand_core 0.6.4",
  "rsa",
  "sec1",
  "sha2",
@@ -2236,6 +2825,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2292,6 +2887,50 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2384,6 +3023,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,6 +3073,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2476,6 +3150,51 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2552,6 +3271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,6 +3318,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2601,6 +3332,30 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2654,10 +3409,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2712,6 +3494,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2866,6 +3711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3026,6 +3880,139 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,7 +4033,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "omnyssh"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,14 @@ chrono = "0.4"
 portable-pty = "0.9"
 vt100 = { package = "vt100-omnyssh", version = "0.15" }
 
+# Update checker — GitHub Releases query, archive extraction, self-replace
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+semver = "1"
+sha2 = "0.10"
+flate2 = "1"
+tar = "0.4"
+self-replace = "1"
+
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnyssh"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 description = "TUI SSH dashboard & server manager"
 license = "Apache-2.0"

--- a/build.rs
+++ b/build.rs
@@ -18,5 +18,10 @@ fn main() {
 
     fs::write(out_dir.join("omny.1"), buf).expect("Failed to write man page");
 
+    // Expose the build target triple so the updater can pick the matching
+    // release asset (e.g. "x86_64-apple-darwin").
+    let target = std::env::var("TARGET").expect("TARGET not set by cargo");
+    println!("cargo:rustc-env=BUILD_TARGET={target}");
+
     println!("cargo:rerun-if-changed=src/cli.rs");
 }

--- a/config/default.toml
+++ b/config/default.toml
@@ -18,3 +18,9 @@ connect = "Enter"
 dashboard = "F1"
 file_manager = "F2"
 snippets = "F3"
+
+[update]
+# Check GitHub Releases for a newer version on startup.
+check_on_startup = true
+# A version to skip; set automatically when you choose "Skip this version".
+skip_version = ""

--- a/doc/omny.1
+++ b/doc/omny.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH omny 1  "omny 1.0.1" 
+.TH omny 1  "omny 1.0.2" 
 .SH NAME
 omny \- TUI SSH dashboard & server manager
 .SH SYNOPSIS
@@ -28,4 +28,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 \fB\-V\fR, \fB\-\-version\fR
 Print version
 .SH VERSION
-v1.0.1
+v1.0.2

--- a/src/app.rs
+++ b/src/app.rs
@@ -475,6 +475,50 @@ pub enum HostPopup {
 }
 
 // ---------------------------------------------------------------------------
+// Update popup
+// ---------------------------------------------------------------------------
+
+/// A button in the startup update popup. Buttons are laid out left-to-right
+/// in [`UPDATE_BUTTONS`] order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateButton {
+    /// Install the update, or — when the app cannot self-update — dismiss the
+    /// popup and check again on the next launch.
+    Primary,
+    /// Never offer this particular version again.
+    Skip,
+    /// Disable update checks entirely.
+    Disable,
+}
+
+/// The three update-popup buttons, in display order.
+pub const UPDATE_BUTTONS: [UpdateButton; 3] = [
+    UpdateButton::Primary,
+    UpdateButton::Skip,
+    UpdateButton::Disable,
+];
+
+/// Lifecycle phase of the update popup.
+#[derive(Debug, Clone)]
+pub enum UpdatePopupPhase {
+    /// Awaiting the user's choice; holds the highlighted button index.
+    Prompt { selected: usize },
+    /// A download + install is in progress.
+    Installing,
+    /// Finished; holds a user-facing message and whether it succeeded.
+    Done { message: String, ok: bool },
+}
+
+/// State of the startup "update available" popup.
+#[derive(Debug, Clone)]
+pub struct UpdatePopup {
+    /// The release that triggered the popup.
+    pub info: crate::update::UpdateInfo,
+    /// Current lifecycle phase.
+    pub phase: UpdatePopupPhase,
+}
+
+// ---------------------------------------------------------------------------
 // Host-list view state (UI-only, not shared with SSH tasks)
 // ---------------------------------------------------------------------------
 
@@ -1173,6 +1217,8 @@ pub struct ViewState {
     pub quick_view: Option<ServiceKind>,
     /// Scroll offset for Quick View popup content.
     pub quick_view_scroll: usize,
+    /// Startup update-notification popup, shown when a newer release exists.
+    pub update_popup: Option<UpdatePopup>,
 }
 
 impl ViewState {
@@ -1192,6 +1238,7 @@ impl ViewState {
             tick_count: 0,
             quick_view: None,
             quick_view_scroll: 0,
+            update_popup: None,
         }
     }
 }
@@ -1231,6 +1278,8 @@ pub struct App {
     /// Consumed at the top of the next main-loop iteration before blocking
     /// on `event_rx.recv()`.
     pending_event: Option<AppEvent>,
+    /// Application config — retained so update preferences can be persisted.
+    config: AppConfig,
 }
 
 impl App {
@@ -1256,6 +1305,7 @@ impl App {
             poll_manager: None,
             pty_manager: None,
             pending_event: None,
+            config,
         }
     }
 }
@@ -1308,6 +1358,20 @@ impl App {
                         let _ = tx.send(AppEvent::SnippetsLoaded(snippets)).await;
                     }
                     Err(e) => tracing::warn!("Failed to load snippets: {}", e),
+                }
+            });
+        }
+
+        // Check GitHub for a newer release in a background task. A failed or
+        // slow check never delays startup; a skipped version is dropped here.
+        if self.config.update.check_on_startup {
+            let tx = self.event_tx.clone();
+            let skip_version = self.config.update.skip_version.clone();
+            tokio::spawn(async move {
+                if let Some(info) = crate::update::check().await {
+                    if info.latest != skip_version {
+                        let _ = tx.send(AppEvent::UpdateAvailable(info)).await;
+                    }
                 }
             });
         }
@@ -1623,6 +1687,36 @@ impl App {
                         "⚠ Key setup rolled back for '{}': {}",
                         host_name, result
                     ));
+                }
+
+                // ----------------------------------------------------------------
+                // Update checker events
+                // ----------------------------------------------------------------
+                AppEvent::UpdateAvailable(info) => {
+                    // Show the popup only if one is not already visible.
+                    if self.view.update_popup.is_none() {
+                        self.view.update_popup = Some(UpdatePopup {
+                            info,
+                            phase: UpdatePopupPhase::Prompt { selected: 0 },
+                        });
+                    }
+                }
+
+                AppEvent::UpdateInstalled(result) => {
+                    if let Some(popup) = &mut self.view.update_popup {
+                        popup.phase = match result {
+                            Ok(()) => UpdatePopupPhase::Done {
+                                message: "Update installed. Restart omny to use \
+                                          the new version."
+                                    .to_string(),
+                                ok: true,
+                            },
+                            Err(err) => UpdatePopupPhase::Done {
+                                message: format!("Update failed: {}", err),
+                                ok: false,
+                            },
+                        };
+                    }
                 }
 
                 // ----------------------------------------------------------------
@@ -1972,7 +2066,102 @@ impl App {
     }
 
     /// Translates a key event into an optional [`AppAction`].
+    /// Handles input while the startup update popup is visible.
+    async fn handle_update_popup_key(&mut self, key: KeyEvent) {
+        let phase = match &self.view.update_popup {
+            Some(popup) => popup.phase.clone(),
+            None => return,
+        };
+
+        match phase {
+            UpdatePopupPhase::Prompt { selected } => match key.code {
+                KeyCode::Left | KeyCode::Char('h') => self.move_update_selection(-1),
+                KeyCode::Right | KeyCode::Char('l') | KeyCode::Tab => self.move_update_selection(1),
+                KeyCode::Enter => {
+                    self.activate_update_choice(UPDATE_BUTTONS[selected]).await;
+                }
+                KeyCode::Esc => self.view.update_popup = None,
+                _ => {}
+            },
+            // Input is ignored while the download/install runs.
+            UpdatePopupPhase::Installing => {}
+            UpdatePopupPhase::Done { .. } => {
+                if matches!(key.code, KeyCode::Enter | KeyCode::Esc) {
+                    self.view.update_popup = None;
+                }
+            }
+        }
+    }
+
+    /// Moves the highlighted update-popup button by `delta`, wrapping around.
+    fn move_update_selection(&mut self, delta: i32) {
+        if let Some(UpdatePopup {
+            phase: UpdatePopupPhase::Prompt { selected },
+            ..
+        }) = &mut self.view.update_popup
+        {
+            let count = UPDATE_BUTTONS.len() as i32;
+            *selected = (*selected as i32 + delta).rem_euclid(count) as usize;
+        }
+    }
+
+    /// Carries out the action bound to the chosen update-popup button.
+    async fn activate_update_choice(&mut self, button: UpdateButton) {
+        let info = match &self.view.update_popup {
+            Some(popup) => popup.info.clone(),
+            None => return,
+        };
+
+        match button {
+            // Self-update: start the download/install in the background.
+            UpdateButton::Primary if info.can_self_update => {
+                if let Some(popup) = &mut self.view.update_popup {
+                    popup.phase = UpdatePopupPhase::Installing;
+                }
+                let tx = self.event_tx.clone();
+                tokio::spawn(async move {
+                    let result = crate::update::perform_update(&info)
+                        .await
+                        .map_err(|e| e.to_string());
+                    let _ = tx.send(AppEvent::UpdateInstalled(result)).await;
+                });
+            }
+            // No self-update available — just dismiss; check again next launch.
+            UpdateButton::Primary => self.view.update_popup = None,
+            // Never offer this version again.
+            UpdateButton::Skip => {
+                self.config.update.skip_version = info.latest.clone();
+                self.persist_update_config();
+                self.view.update_popup = None;
+            }
+            // Turn off update checks entirely.
+            UpdateButton::Disable => {
+                self.config.update.check_on_startup = false;
+                self.persist_update_config();
+                self.view.update_popup = None;
+            }
+        }
+    }
+
+    /// Persists the update preferences. A failure is logged, never surfaced —
+    /// it must not block dismissing the popup.
+    fn persist_update_config(&self) {
+        if let Err(e) = config::app_config::save_update_config(&self.config.update) {
+            tracing::warn!("Failed to save update config: {}", e);
+        }
+    }
+
     async fn handle_key(&mut self, key: KeyEvent) -> anyhow::Result<Option<AppAction>> {
+        // The update popup is modal — it captures all input until dismissed.
+        // Ctrl+C still quits as an escape hatch.
+        if self.view.update_popup.is_some() {
+            if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+                return Ok(Some(AppAction::Quit));
+            }
+            self.handle_update_popup_key(key).await;
+            return Ok(None);
+        }
+
         let screen = self.state.read().await.screen.clone();
 
         // ----------------------------------------------------------------

--- a/src/config/app_config.rs
+++ b/src/config/app_config.rs
@@ -473,4 +473,32 @@ mod tests {
         let kb = parse_keybind("F5").unwrap();
         assert!(!kb.ctrl);
     }
+
+    #[test]
+    fn update_config_defaults_to_enabled() {
+        let cfg = UpdateConfig::default();
+        assert!(cfg.check_on_startup);
+        assert!(cfg.skip_version.is_empty());
+    }
+
+    /// A config file written by an older release (no `[update]` section)
+    /// must still parse, falling back to the default update settings.
+    #[test]
+    fn config_without_update_section_parses() {
+        let cfg: AppConfig = toml::from_str("[ui]\ntheme = \"nord\"\n").unwrap();
+        assert_eq!(cfg.ui.theme, "nord");
+        assert!(cfg.update.check_on_startup);
+    }
+
+    #[test]
+    fn update_config_round_trips_through_toml() {
+        let mut cfg = AppConfig::default();
+        cfg.update.check_on_startup = false;
+        cfg.update.skip_version = "1.2.3".to_string();
+
+        let serialized = toml::to_string_pretty(&cfg).unwrap();
+        let parsed: AppConfig = toml::from_str(&serialized).unwrap();
+        assert!(!parsed.update.check_on_startup);
+        assert_eq!(parsed.update.skip_version, "1.2.3");
+    }
 }

--- a/src/config/app_config.rs
+++ b/src/config/app_config.rs
@@ -12,6 +12,7 @@ pub struct AppConfig {
     pub keybindings: KeybindingsConfig,
     pub smart_context: SmartContextConfig,
     pub auto_key_setup: AutoKeySetupConfig,
+    pub update: UpdateConfig,
 }
 
 /// General / runtime settings.
@@ -159,6 +160,25 @@ impl Default for AutoKeySetupConfig {
             key_directory: String::from("~/.ssh"),
             backup_sshd_config: true,
             confirm_before_disable: true,
+        }
+    }
+}
+
+/// Update checker configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct UpdateConfig {
+    /// Check GitHub Releases for a newer version on startup.
+    pub check_on_startup: bool,
+    /// A version the user chose to skip; it is never offered again.
+    pub skip_version: String,
+}
+
+impl Default for UpdateConfig {
+    fn default() -> Self {
+        Self {
+            check_on_startup: true,
+            skip_version: String::new(),
         }
     }
 }
@@ -363,14 +383,12 @@ pub fn load_app_config(path: Option<&std::path::Path>) -> anyhow::Result<AppConf
     Ok(config)
 }
 
-/// Saves the theme selection to the config file.
-///
-/// If the config file doesn't exist, it creates a new one with the theme setting.
-/// If it exists, it updates the `[ui]` section's `theme` field.
+/// Loads the on-disk config (or a default), applies `mutator`, and writes it
+/// back. Reading fresh from disk avoids clobbering unrelated edits.
 ///
 /// # Errors
-/// Returns an error if the config file cannot be written or parsed.
-pub fn save_theme_to_config(theme_name: &str) -> anyhow::Result<()> {
+/// Returns an error if the config file cannot be read, parsed, or written.
+fn persist_config<F: FnOnce(&mut AppConfig)>(mutator: F) -> anyhow::Result<()> {
     use crate::utils::platform;
 
     let config_path = match platform::app_config_path() {
@@ -378,13 +396,11 @@ pub fn save_theme_to_config(theme_name: &str) -> anyhow::Result<()> {
         None => anyhow::bail!("Cannot determine config path for this platform"),
     };
 
-    // Ensure config directory exists
     if let Some(parent) = config_path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("Failed to create config directory: {}", parent.display()))?;
     }
 
-    // Load existing config or create default
     let mut config = if config_path.exists() {
         let content = std::fs::read_to_string(&config_path)
             .with_context(|| format!("Failed to read config: {}", config_path.display()))?;
@@ -394,16 +410,31 @@ pub fn save_theme_to_config(theme_name: &str) -> anyhow::Result<()> {
         AppConfig::default()
     };
 
-    // Update theme
-    config.ui.theme = theme_name.to_string();
+    mutator(&mut config);
 
-    // Serialize and write back
     let content = toml::to_string_pretty(&config).context("Failed to serialize config")?;
-
     std::fs::write(&config_path, content)
         .with_context(|| format!("Failed to write config: {}", config_path.display()))?;
 
     Ok(())
+}
+
+/// Saves the theme selection to the config file's `[ui]` section.
+///
+/// # Errors
+/// Returns an error if the config file cannot be written or parsed.
+pub fn save_theme_to_config(theme_name: &str) -> anyhow::Result<()> {
+    persist_config(|config| config.ui.theme = theme_name.to_string())
+}
+
+/// Saves the update-checker preferences to the config file's `[update]`
+/// section.
+///
+/// # Errors
+/// Returns an error if the config file cannot be written or parsed.
+pub fn save_update_config(update: &UpdateConfig) -> anyhow::Result<()> {
+    let update = update.clone();
+    persist_config(move |config| config.update = update)
 }
 
 #[cfg(test)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -136,6 +136,14 @@ pub enum AppEvent {
     KeySetupFailed(HostId, String),
     /// Emergency rollback was triggered (host_id, rollback_result).
     KeySetupRollback(HostId, String),
+
+    // -----------------------------------------------------------------------
+    // Update checker events
+    // -----------------------------------------------------------------------
+    /// A newer release was found on GitHub at startup.
+    UpdateAvailable(crate::update::UpdateInfo),
+    /// A self-update finished — `Ok` on success, `Err` with a message on failure.
+    UpdateInstalled(Result<(), String>),
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,5 @@ pub mod config;
 pub mod event;
 pub mod ssh;
 pub mod ui;
+pub mod update;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod config;
 mod event;
 mod ssh;
 mod ui;
+mod update;
 mod utils;
 
 #[tokio::main]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -83,4 +83,9 @@ pub fn render(frame: &mut Frame, state: &AppState, view: &ViewState) {
     if view.show_help {
         popup::render_help(frame, &view.theme);
     }
+
+    // The startup update popup sits above everything else.
+    if let Some(update_popup) = &view.update_popup {
+        popup::render_update(frame, update_popup, &view.theme);
+    }
 }

--- a/src/ui/popup.rs
+++ b/src/ui/popup.rs
@@ -7,8 +7,8 @@ use ratatui::{
 };
 
 use crate::app::{
-    FormField, HostForm, SnippetForm, SnippetResultEntry, FORM_FIELD_LABELS,
-    SNIPPET_FORM_FIELD_LABELS,
+    FormField, HostForm, SnippetForm, SnippetResultEntry, UpdateButton, UpdatePopup,
+    UpdatePopupPhase, FORM_FIELD_LABELS, SNIPPET_FORM_FIELD_LABELS, UPDATE_BUTTONS,
 };
 use crate::ssh::client::Host;
 use crate::ui::theme::Theme;
@@ -1576,4 +1576,188 @@ pub fn render_key_setup_progress(
             hint_row,
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// Update popup
+// ---------------------------------------------------------------------------
+
+/// Label shown on an update-popup button.
+fn update_button_label(button: UpdateButton, can_self_update: bool) -> &'static str {
+    match button {
+        UpdateButton::Primary if can_self_update => "Update now",
+        UpdateButton::Primary => "Remind me later",
+        UpdateButton::Skip => "Skip this version",
+        UpdateButton::Disable => "Don't check again",
+    }
+}
+
+/// Renders the startup "update available" popup.
+pub fn render_update(frame: &mut Frame, popup: &UpdatePopup, theme: &Theme) {
+    let area = centred_rect(62, 42, frame.area());
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Update Available ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.accent));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Reserve the last two rows for the action buttons and the hint.
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    // ── Body text ──────────────────────────────────────────────
+    let mut lines: Vec<Line> = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Version  ", Style::default().fg(theme.text_secondary)),
+            Span::styled(
+                popup.info.current.clone(),
+                Style::default().fg(theme.text_muted),
+            ),
+            Span::styled("  →  ", Style::default().fg(theme.text_secondary)),
+            Span::styled(
+                popup.info.latest.clone(),
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(""),
+    ];
+
+    let info_style = Style::default().fg(theme.text_primary);
+    let emphasis_style = Style::default()
+        .fg(theme.text_warning)
+        .add_modifier(Modifier::BOLD);
+
+    match &popup.phase {
+        UpdatePopupPhase::Prompt { .. } => {
+            if popup.info.can_self_update {
+                lines.push(Line::from(Span::styled(
+                    "  This update can be downloaded and installed now.",
+                    info_style,
+                )));
+                lines.push(Line::from(Span::styled(
+                    "  The archive checksum is verified before installing.",
+                    Style::default().fg(theme.text_muted),
+                )));
+            } else if let Some(cmd) = popup.info.method.upgrade_command() {
+                lines.push(Line::from(Span::styled(
+                    "  Update it with your package manager:",
+                    info_style,
+                )));
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    format!("    {cmd}"),
+                    emphasis_style,
+                )));
+            } else {
+                lines.push(Line::from(Span::styled(
+                    "  Download the new release from:",
+                    info_style,
+                )));
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    format!("    {}", popup.info.release_url()),
+                    emphasis_style,
+                )));
+            }
+        }
+        UpdatePopupPhase::Installing => {
+            let spinner = SPINNER_FRAMES[(frame.count() / 2) % SPINNER_FRAMES.len()];
+            lines.push(Line::from(Span::styled(
+                format!("  {spinner} Downloading and installing — please wait…"),
+                Style::default().fg(theme.text_warning),
+            )));
+        }
+        UpdatePopupPhase::Done { message, ok } => {
+            let color = if *ok {
+                theme.text_success
+            } else {
+                theme.text_error
+            };
+            for line in message.lines() {
+                lines.push(Line::from(Span::styled(
+                    format!("  {line}"),
+                    Style::default().fg(color),
+                )));
+            }
+        }
+    }
+
+    frame.render_widget(Paragraph::new(lines), rows[0]);
+
+    // ── Action row ─────────────────────────────────────────────
+    if let UpdatePopupPhase::Prompt { selected } = &popup.phase {
+        let mut spans: Vec<Span> = vec![Span::raw("  ")];
+        for (i, &button) in UPDATE_BUTTONS.iter().enumerate() {
+            let label = update_button_label(button, popup.info.can_self_update);
+            let style = if i == *selected {
+                Style::default()
+                    .fg(theme.form_focused_fg)
+                    .bg(theme.accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.text_secondary)
+            };
+            spans.push(Span::styled(format!(" {label} "), style));
+            spans.push(Span::raw("  "));
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), rows[1]);
+    }
+
+    // ── Hint row ───────────────────────────────────────────────
+    let hint = match &popup.phase {
+        UpdatePopupPhase::Prompt { .. } => Line::from(vec![
+            Span::styled(
+                "  ←/→",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(":select  ", Style::default().fg(theme.text_muted)),
+            Span::styled(
+                "Enter",
+                Style::default()
+                    .fg(theme.text_success)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(":confirm  ", Style::default().fg(theme.text_muted)),
+            Span::styled(
+                "Esc",
+                Style::default()
+                    .fg(theme.text_warning)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(":dismiss", Style::default().fg(theme.text_muted)),
+        ]),
+        UpdatePopupPhase::Installing => Line::from(Span::styled(
+            "  Please wait…",
+            Style::default()
+                .fg(theme.text_muted)
+                .add_modifier(Modifier::ITALIC),
+        )),
+        UpdatePopupPhase::Done { .. } => Line::from(vec![
+            Span::styled(
+                "  Enter / Esc",
+                Style::default()
+                    .fg(theme.text_warning)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(":close", Style::default().fg(theme.text_muted)),
+        ]),
+    };
+    frame.render_widget(Paragraph::new(hint), rows[2]);
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,395 @@
+//! In-app update checker.
+//!
+//! On startup OmnySSH queries the GitHub Releases API for the latest version.
+//! Depending on how the binary was installed it can either self-replace the
+//! executable (manual / `install.sh` installs on Linux and macOS) or show the
+//! package-manager command the user should run instead.
+
+use std::io::Read;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use flate2::read::GzDecoder;
+use semver::Version;
+use sha2::{Digest, Sha256};
+use tar::Archive;
+
+/// GitHub repository that hosts OmnySSH releases.
+const REPO: &str = "timhartmann7/omnyssh";
+/// Timeout applied to every network request the updater makes.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(8);
+/// Target triple this binary was built for (provided by `build.rs`).
+const BUILD_TARGET: &str = env!("BUILD_TARGET");
+
+// ---------------------------------------------------------------------------
+// Install method
+// ---------------------------------------------------------------------------
+
+/// How the running binary was installed. Determines whether an in-app
+/// self-update is possible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallMethod {
+    /// `install.sh` or a manually placed binary — eligible for self-update.
+    Manual,
+    Homebrew,
+    Cargo,
+    Nix,
+}
+
+impl InstallMethod {
+    /// Detects the install method of the currently running executable.
+    pub fn detect() -> Self {
+        match std::env::current_exe() {
+            Ok(path) => Self::from_path(&path),
+            Err(_) => Self::Manual,
+        }
+    }
+
+    /// Classifies an executable path by well-known install locations.
+    fn from_path(path: &Path) -> Self {
+        let p = path.to_string_lossy();
+        if p.contains("/nix/store/") {
+            Self::Nix
+        } else if p.contains("/Cellar/") || p.contains("/homebrew/") {
+            Self::Homebrew
+        } else if p.contains("/.cargo/") {
+            Self::Cargo
+        } else {
+            Self::Manual
+        }
+    }
+
+    /// Command the user runs to upgrade through this install method.
+    /// `None` means the app is able to perform the update itself.
+    pub fn upgrade_command(self) -> Option<&'static str> {
+        match self {
+            Self::Manual => None,
+            Self::Homebrew => Some("brew upgrade omnyssh"),
+            Self::Cargo => Some("cargo install omnyssh --force"),
+            Self::Nix => Some("nix profile upgrade omnyssh"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Update info
+// ---------------------------------------------------------------------------
+
+/// A newer release discovered by [`check`].
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    /// Version this binary reports (without a leading `v`).
+    pub current: String,
+    /// Latest released version (without a leading `v`).
+    pub latest: String,
+    /// Git tag of the latest release (e.g. `v1.0.2`).
+    pub tag: String,
+    /// How this binary was installed.
+    pub method: InstallMethod,
+    /// Whether the app can download and install this update itself.
+    pub can_self_update: bool,
+}
+
+impl UpdateInfo {
+    /// URL of the release page, shown when the app cannot self-update.
+    pub fn release_url(&self) -> String {
+        format!("https://github.com/{REPO}/releases/tag/{}", self.tag)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Version check
+// ---------------------------------------------------------------------------
+
+/// Queries GitHub for the latest release. Returns `Some` only when a strictly
+/// newer version exists. Any network or parse error yields `None`, so a failed
+/// check never disrupts startup.
+pub async fn check() -> Option<UpdateInfo> {
+    let current = env!("CARGO_PKG_VERSION");
+    let tag = fetch_latest_tag().await.ok()?;
+    let latest = tag.trim_start_matches('v').to_string();
+
+    if !is_newer(&latest, current) {
+        return None;
+    }
+
+    let method = InstallMethod::detect();
+    Some(UpdateInfo {
+        current: current.to_string(),
+        latest,
+        tag,
+        method,
+        can_self_update: method == InstallMethod::Manual
+            && cfg!(any(target_os = "linux", target_os = "macos"))
+            && binary_is_replaceable(),
+    })
+}
+
+/// Returns `true` when `latest` is a strictly greater semver than `current`.
+/// An unparseable version yields `false` — never nag on bad data.
+fn is_newer(latest: &str, current: &str) -> bool {
+    match (Version::parse(latest), Version::parse(current)) {
+        (Ok(l), Ok(c)) => l > c,
+        _ => false,
+    }
+}
+
+/// Minimal subset of the GitHub release JSON payload.
+#[derive(serde::Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+}
+
+/// Fetches the `tag_name` of the latest (non-prerelease) GitHub release.
+async fn fetch_latest_tag() -> Result<String> {
+    let url = format!("https://api.github.com/repos/{REPO}/releases/latest");
+    let release: GithubRelease = http_client()?
+        .get(&url)
+        .send()
+        .await
+        .context("release request failed")?
+        .error_for_status()
+        .context("release request returned an error status")?
+        .json()
+        .await
+        .context("failed to decode release JSON")?;
+    Ok(release.tag_name)
+}
+
+// ---------------------------------------------------------------------------
+// Self-update
+// ---------------------------------------------------------------------------
+
+/// Downloads the release archive for [`BUILD_TARGET`], verifies its SHA-256
+/// against the release `SHA256SUMS`, and replaces the running executable.
+///
+/// Only valid when [`UpdateInfo::can_self_update`] is `true`.
+pub async fn perform_update(info: &UpdateInfo) -> Result<()> {
+    let archive_name = format!("omny-{BUILD_TARGET}.tar.gz");
+    let base = format!("https://github.com/{REPO}/releases/download/{}", info.tag);
+    let client = http_client()?;
+
+    let archive = download_bytes(&client, &format!("{base}/{archive_name}"))
+        .await
+        .context("failed to download release archive")?;
+    let sums = download_text(&client, &format!("{base}/SHA256SUMS"))
+        .await
+        .context("failed to download SHA256SUMS")?;
+
+    verify_checksum(&archive, &sums, &archive_name)?;
+
+    let binary = extract_binary(&archive).context("failed to extract binary from archive")?;
+    install_binary(&binary).context("failed to replace the running executable")?;
+    Ok(())
+}
+
+/// Builds the shared HTTP client. GitHub requires a `User-Agent` header.
+fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent(concat!("omnyssh/", env!("CARGO_PKG_VERSION")))
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .context("failed to build HTTP client")
+}
+
+async fn download_bytes(client: &reqwest::Client, url: &str) -> Result<Vec<u8>> {
+    let bytes = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+    Ok(bytes.to_vec())
+}
+
+async fn download_text(client: &reqwest::Client, url: &str) -> Result<String> {
+    let text = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    Ok(text)
+}
+
+/// Verifies `archive` bytes against the `SHA256SUMS` entry for `archive_name`.
+fn verify_checksum(archive: &[u8], sums: &str, archive_name: &str) -> Result<()> {
+    let expected = sums
+        .lines()
+        .find_map(|line| {
+            let (hash, name) = line.split_once("  ")?;
+            (name.trim() == archive_name).then(|| hash.trim().to_lowercase())
+        })
+        .with_context(|| format!("no checksum entry for {archive_name}"))?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(archive);
+    let actual = format!("{:x}", hasher.finalize());
+
+    if actual != expected {
+        anyhow::bail!("checksum mismatch: expected {expected}, got {actual}");
+    }
+    Ok(())
+}
+
+/// Extracts the `omny` binary from a gzip-compressed tar archive.
+fn extract_binary(archive: &[u8]) -> Result<Vec<u8>> {
+    let mut tar = Archive::new(GzDecoder::new(archive));
+    for entry in tar.entries().context("invalid tar archive")? {
+        let mut entry = entry.context("invalid tar entry")?;
+        let is_binary = entry
+            .path()
+            .ok()
+            .and_then(|p| p.file_name().map(|n| n.to_os_string()))
+            .is_some_and(|n| n == "omny");
+        if is_binary {
+            let mut buf = Vec::new();
+            entry
+                .read_to_end(&mut buf)
+                .context("failed to read binary")?;
+            return Ok(buf);
+        }
+    }
+    anyhow::bail!("archive does not contain the omny binary")
+}
+
+/// Writes `binary` to a temp file next to the current executable and
+/// atomically swaps it in.
+fn install_binary(binary: &[u8]) -> Result<()> {
+    let exe = std::env::current_exe().context("cannot locate current executable")?;
+    let dir = exe.parent().context("executable has no parent directory")?;
+    let tmp = dir.join(format!(".omny-update-{}", std::process::id()));
+
+    std::fs::write(&tmp, binary).with_context(|| format!("failed to write {}", tmp.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755))
+            .context("failed to mark binary executable")?;
+    }
+
+    let result = self_replace::self_replace(&tmp).context("self-replace failed");
+    let _ = std::fs::remove_file(&tmp);
+    result
+}
+
+/// Checks whether the running executable's directory is writable by creating
+/// and removing a probe file. `self_replace` writes the replacement there
+/// before swapping it in, so a writable directory is required.
+fn binary_is_replaceable() -> bool {
+    let Ok(exe) = std::env::current_exe() else {
+        return false;
+    };
+    let Some(dir) = exe.parent() else {
+        return false;
+    };
+    let probe = dir.join(format!(".omny-update-probe-{}", std::process::id()));
+    match std::fs::File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn detects_install_method_from_path() {
+        let cases = [
+            ("/home/u/.cargo/bin/omny", InstallMethod::Cargo),
+            (
+                "/opt/homebrew/Cellar/omnyssh/1.0.1/bin/omny",
+                InstallMethod::Homebrew,
+            ),
+            ("/usr/local/homebrew/bin/omny", InstallMethod::Homebrew),
+            ("/nix/store/abc-omnyssh-1.0.1/bin/omny", InstallMethod::Nix),
+            ("/usr/local/bin/omny", InstallMethod::Manual),
+            ("/home/u/bin/omny", InstallMethod::Manual),
+        ];
+        for (path, expected) in cases {
+            assert_eq!(
+                InstallMethod::from_path(&PathBuf::from(path)),
+                expected,
+                "{path}"
+            );
+        }
+    }
+
+    #[test]
+    fn upgrade_command_only_for_package_managers() {
+        assert!(InstallMethod::Manual.upgrade_command().is_none());
+        assert!(InstallMethod::Homebrew.upgrade_command().is_some());
+        assert!(InstallMethod::Cargo.upgrade_command().is_some());
+        assert!(InstallMethod::Nix.upgrade_command().is_some());
+    }
+
+    #[test]
+    fn is_newer_compares_semver() {
+        assert!(is_newer("1.0.2", "1.0.1"));
+        assert!(is_newer("1.1.0", "1.0.9"));
+        assert!(is_newer("2.0.0", "1.9.9"));
+        assert!(!is_newer("1.0.1", "1.0.1"));
+        assert!(!is_newer("1.0.0", "1.0.1"));
+        // Unparseable versions never trigger an update prompt.
+        assert!(!is_newer("not-a-version", "1.0.1"));
+        assert!(!is_newer("1.0.2", "garbage"));
+    }
+
+    /// Builds a gzip-compressed tar archive containing the given files.
+    fn make_targz(files: &[(&str, &[u8])]) -> Vec<u8> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let mut builder = tar::Builder::new(GzEncoder::new(Vec::new(), Compression::fast()));
+        for (name, data) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append_data(&mut header, name, *data).unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    #[test]
+    fn extracts_omny_binary_from_archive() {
+        let archive = make_targz(&[("omny", b"fake-binary-bytes")]);
+        let binary = extract_binary(&archive).expect("extract");
+        assert_eq!(binary, b"fake-binary-bytes");
+    }
+
+    #[test]
+    fn extract_fails_when_binary_absent() {
+        let archive = make_targz(&[("readme.txt", b"hello")]);
+        assert!(extract_binary(&archive).is_err());
+    }
+
+    #[test]
+    fn checksum_verification() {
+        let archive = b"release archive contents";
+        let mut hasher = Sha256::new();
+        hasher.update(archive);
+        let digest = format!("{:x}", hasher.finalize());
+
+        let sums = format!("{digest}  omny-x86_64-apple-darwin.tar.gz\nffff  omny-other.tar.gz\n");
+        assert!(verify_checksum(archive, &sums, "omny-x86_64-apple-darwin.tar.gz").is_ok());
+
+        // Wrong contents fail.
+        assert!(verify_checksum(b"tampered", &sums, "omny-x86_64-apple-darwin.tar.gz").is_err());
+        // Missing entry fails.
+        assert!(verify_checksum(archive, &sums, "omny-missing.tar.gz").is_err());
+    }
+}


### PR DESCRIPTION
On startup OmnySSH now checks GitHub Releases for a newer version and shows a popup when one exists.

- Self-update for manual / `install.sh` installs on Linux & macOS, with SHA-256 checksum verification before the binary is replaced.
- Homebrew / Cargo / Nix installs show the matching upgrade command.
- Popup actions: install · skip version · disable checks (`[update]` config).
- Release workflow now publishes `SHA256SUMS`; bumped to `1.0.2`.

All checks pass: build, clippy, fmt, tests (12 new).