### PR TITLE
Fix/ssh connection hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - **Multi-line paste into the terminal fixed**: Bracketed paste is now implemented. Pasting multi-line text into the Terminal screen no longer drops the first characters, and editors like `vim` insert it verbatim without cascading auto-indent.
 - **Top processes exclude OmnySSH's own connection**: The detail-page top-processes panel no longer lists OmnySSH's metric-polling SSH connection. Its `sshd` process chain is filtered out by PID, so an idle server shows real workload while SSH sessions from other users still appear.
 - **Bracketed paste restored after system SSH**: Connecting to a host via the system `ssh` binary no longer leaves bracketed paste disabled on return, so multi-line paste into the terminal keeps working.
+- **Host keys are now verified**: A server's host key is recorded in `~/.ssh/known_hosts` on first connection (trust on first use). A later key change — or an unreadable `known_hosts` — refuses the connection instead of silently accepting an unverified key.
+- **Password authentication reliably disabled**: Auto SSH Key Setup now adds the `PasswordAuthentication`, `UsePAM`, and challenge/keyboard-interactive directives when `sshd_config` omits them, so password login is disabled even on configs that previously relied on compiled-in defaults.
+- **System SSH launch failure no longer quits the app**: If the `ssh` binary cannot be started, OmnySSH restores the TUI and reports the error in the status bar instead of exiting.
+- **Remote command exit status honoured**: SSH command execution now exposes a non-zero remote exit status; the key-setup sudo check uses it to detect missing sudo access correctly.
 
 ### Other
 - Release archives are now published alongside a `SHA256SUMS` checksum file.

--- a/src/app/host.rs
+++ b/src/app/host.rs
@@ -560,13 +560,7 @@ impl App {
         host: &Host,
     ) -> anyhow::Result<()> {
         // 1. Leave TUI mode.
-        crossterm::terminal::disable_raw_mode()?;
-        crossterm::execute!(
-            std::io::stdout(),
-            crossterm::terminal::LeaveAlternateScreen,
-            crate::utils::mouse::DisableMinimalMouseCapture,
-            crossterm::event::DisableBracketedPaste,
-        )?;
+        leave_tui()?;
 
         // 2. Build SSH command (ConnectTimeout=10).
         let mut cmd = tokio::process::Command::new("ssh");
@@ -582,34 +576,57 @@ impl App {
         }
         cmd.arg(format!("{}@{}", host.user, host.hostname));
 
-        // 3. Hand off terminal control to SSH.
+        // 3. Hand off terminal control to SSH. A spawn/wait failure (e.g. no
+        //    `ssh` binary on PATH) must not abort the app — the TUI is still
+        //    restored below and the error is shown in the status bar.
         tracing::info!("Connecting to {} via system SSH", host.name);
-        let status = cmd.spawn()?.wait().await?;
+        let outcome = match cmd.spawn() {
+            Ok(mut child) => child.wait().await,
+            Err(e) => Err(e),
+        };
 
         // 4. Re-enter TUI mode. Bracketed paste is re-enabled here because the
         // remote shell may have left it disabled when the SSH session ended.
-        crossterm::terminal::enable_raw_mode()?;
-        crossterm::execute!(
-            std::io::stdout(),
-            crossterm::terminal::EnterAlternateScreen,
-            crate::utils::mouse::EnableMinimalMouseCapture,
-            crossterm::event::EnableBracketedPaste,
-        )?;
+        enter_tui()?;
         terminal.clear()?;
 
         // 5. Show connection result.
-        self.view.status_message = Some(if status.success() {
-            format!("Disconnected from '{}'.", host.name)
-        } else {
-            format!(
+        self.view.status_message = Some(match outcome {
+            Ok(status) if status.success() => format!("Disconnected from '{}'.", host.name),
+            Ok(status) => format!(
                 "SSH to '{}' exited with code {:?}.",
                 host.name,
                 status.code()
-            )
+            ),
+            Err(e) => format!("Failed to launch ssh for '{}': {e}", host.name),
         });
 
         Ok(())
     }
+}
+
+/// Leaves the omnyssh TUI so a child process can own the terminal.
+fn leave_tui() -> anyhow::Result<()> {
+    crossterm::terminal::disable_raw_mode()?;
+    crossterm::execute!(
+        std::io::stdout(),
+        crossterm::terminal::LeaveAlternateScreen,
+        crate::utils::mouse::DisableMinimalMouseCapture,
+        crossterm::event::DisableBracketedPaste,
+    )?;
+    Ok(())
+}
+
+/// Re-enters the omnyssh TUI after a child process has exited.
+fn enter_tui() -> anyhow::Result<()> {
+    crossterm::terminal::enable_raw_mode()?;
+    crossterm::execute!(
+        std::io::stdout(),
+        crossterm::terminal::EnterAlternateScreen,
+        crate::utils::mouse::EnableMinimalMouseCapture,
+        crossterm::event::EnableBracketedPaste,
+    )?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/ssh/key_setup.rs
+++ b/src/ssh/key_setup.rs
@@ -620,10 +620,11 @@ async fn setup_key_internal(
         }
     }
 
-    // Check sudo availability.
+    // Check sudo availability. `run_command_checked` is required here — the
+    // probe's exit status is the answer, and plain `run_command` ignores it.
     info!("Checking sudo availability");
     match password_session
-        .run_command("sudo -n true 2>/dev/null")
+        .run_command_checked("sudo -n true 2>/dev/null")
         .await
     {
         Ok(_) => {

--- a/src/ssh/key_setup.rs
+++ b/src/ssh/key_setup.rs
@@ -428,19 +428,42 @@ pub fn build_authorized_keys_command(public_key: &str) -> String {
 /// (e.g., `50-cloud-init.conf`) that override the main config. We comment out the Include
 /// directive to prevent these files from re-enabling password authentication.
 ///
+/// ## Missing Directives
+/// `sed` only rewrites lines that already exist. A config that simply omits a
+/// directive would otherwise keep sshd's compiled-in default (e.g. `UsePAM yes`),
+/// so each directive is also prepended when the file contains no occurrence.
+/// Prepending keeps it the first — and therefore effective — global value.
+///
 /// Returns the command string or an error if sudo is required but unavailable.
 pub fn build_disable_password_command() -> String {
     let timestamp = chrono::Utc::now().format("%Y%m%d_%H%M%S");
+    let password = force_sshd_directive("PasswordAuthentication", "no");
+    let challenge = force_sshd_directive("ChallengeResponseAuthentication", "no");
+    let kbd = force_sshd_directive("KbdInteractiveAuthentication", "no");
+    let pam = force_sshd_directive("UsePAM", "no");
 
     format!(
         r#"sudo -n true 2>/dev/null || {{ echo "OMNYSSH_NO_SUDO"; exit 1; }}; \
            sudo cp /etc/ssh/sshd_config /etc/ssh/sshd_config.omnyssh_backup.{timestamp} && \
            sudo sed -i.bak 's/^Include\s/#Include /' /etc/ssh/sshd_config && \
-           sudo sed -i.bak 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config && \
-           sudo sed -i.bak 's/^#\?ChallengeResponseAuthentication.*/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config && \
-           sudo sed -i.bak 's/^#\?KbdInteractiveAuthentication.*/KbdInteractiveAuthentication no/' /etc/ssh/sshd_config && \
-           sudo sed -i.bak 's/^#\?UsePAM.*/UsePAM no/' /etc/ssh/sshd_config && \
+           {password} && \
+           {challenge} && \
+           {kbd} && \
+           {pam} && \
            sudo sshd -t || {{ echo "OMNYSSH_CONFIG_ERROR"; sudo cp /etc/ssh/sshd_config.omnyssh_backup.{timestamp} /etc/ssh/sshd_config; exit 1; }}"#
+    )
+}
+
+/// Builds the shell fragment that forces `sshd_config` to set `directive value`.
+///
+/// First rewrites every existing column-0 occurrence (commented or not) to the
+/// desired value; then, if the file had none, prepends the directive so it
+/// becomes the first global occurrence sshd reads.
+fn force_sshd_directive(directive: &str, value: &str) -> String {
+    format!(
+        r#"sudo sed -i.bak 's/^#\?{directive}.*/{directive} {value}/' /etc/ssh/sshd_config && \
+           {{ sudo grep -qE '^{directive}[[:space:]]' /etc/ssh/sshd_config || \
+              sudo sed -i '1i {directive} {value}' /etc/ssh/sshd_config; }}"#
     )
 }
 
@@ -907,6 +930,17 @@ mod tests {
         assert!(cmd.contains("KbdInteractiveAuthentication no"));
         // Should disable PAM to prevent bypassing password auth.
         assert!(cmd.contains("UsePAM no"));
+    }
+
+    #[test]
+    fn test_disable_password_command_adds_missing_directives() {
+        let cmd = build_disable_password_command();
+
+        // Each directive is prepended when the config contains no occurrence.
+        assert!(cmd.contains("grep -qE '^PasswordAuthentication[[:space:]]'"));
+        assert!(cmd.contains("sed -i '1i PasswordAuthentication no'"));
+        assert!(cmd.contains("grep -qE '^UsePAM[[:space:]]'"));
+        assert!(cmd.contains("sed -i '1i UsePAM no'"));
     }
 
     #[test]

--- a/src/ssh/session.rs
+++ b/src/ssh/session.rs
@@ -128,11 +128,33 @@ impl SshSession {
     /// Execute a shell command on the remote host and return its stdout.
     ///
     /// A new SSH channel is opened for each call so sessions can be
-    /// reused across multiple commands.
+    /// reused across multiple commands. The remote exit status is ignored —
+    /// use [`SshSession::run_command_checked`] when it carries the result.
     ///
     /// # Errors
     /// Returns an error on channel failure or if the command times out (30 s).
     pub async fn run_command(&self, cmd: &str) -> anyhow::Result<String> {
+        Ok(self.exec(cmd).await?.0)
+    }
+
+    /// Like [`SshSession::run_command`] but returns an error when the remote
+    /// command exits with a non-zero status. Use for `test`-style probes whose
+    /// exit code is the answer (e.g. `sudo -n true`).
+    ///
+    /// # Errors
+    /// As [`SshSession::run_command`], plus a non-zero remote exit status.
+    pub async fn run_command_checked(&self, cmd: &str) -> anyhow::Result<String> {
+        let (output, status) = self.exec(cmd).await?;
+        match status {
+            // A missing exit status is treated as success — failing a command
+            // that likely worked is worse than missing a rare edge case.
+            None | Some(0) => Ok(output),
+            Some(code) => Err(anyhow!("remote command exited with status {code}")),
+        }
+    }
+
+    /// Opens a channel, runs `cmd`, and returns its stdout and exit status.
+    async fn exec(&self, cmd: &str) -> anyhow::Result<(String, Option<u32>)> {
         let mut channel = self
             .handle
             .channel_open_session()
@@ -141,12 +163,10 @@ impl SshSession {
 
         channel.exec(true, cmd).await.context("exec SSH command")?;
 
-        let output = time::timeout(Duration::from_secs(30), collect_output(&mut channel))
+        time::timeout(Duration::from_secs(30), collect_output(&mut channel))
             .await
             .map_err(|_| anyhow!("command timed out (30 s): {}", cmd))?
-            .context("read command output")?;
-
-        Ok(output)
+            .context("read command output")
     }
 
     /// Opens a new SSH channel, requests the SFTP subsystem, and returns the
@@ -325,8 +345,9 @@ async fn try_password_auth(
 
 async fn collect_output(
     channel: &mut russh::Channel<russh::client::Msg>,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<(String, Option<u32>)> {
     let mut buf = Vec::new();
+    let mut exit_status = None;
     loop {
         match channel.wait().await {
             Some(ChannelMsg::Data { ref data }) => {
@@ -335,16 +356,19 @@ async fn collect_output(
             Some(ChannelMsg::ExtendedData { .. }) => {
                 // stderr — discard to avoid corrupting stdout-only parser input
             }
-            Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) => break,
-            Some(ChannelMsg::ExitStatus { .. }) => break,
-            None => break,
+            Some(ChannelMsg::ExitStatus { exit_status: code }) => {
+                // Record it but keep reading: trailing stdout may still arrive
+                // before the channel is closed.
+                exit_status = Some(code);
+            }
+            Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => break,
             _ => {}
         }
     }
     // Use .lines() semantics: replace \r\n → \n for cross-platform safety.
     let raw = String::from_utf8_lossy(&buf);
     let normalised: String = raw.lines().flat_map(|l| [l, "\n"]).collect();
-    Ok(normalised)
+    Ok((normalised, exit_status))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ssh/session.rs
+++ b/src/ssh/session.rs
@@ -26,7 +26,8 @@ use crate::ssh::client::Host;
 /// Minimal russh client handler for metric collection.
 ///
 /// Verifies the server's host key against `~/.ssh/known_hosts`.
-/// Unknown hosts (first connection) are accepted; changed keys are rejected.
+/// Unknown hosts are recorded on first connection (trust on first use);
+/// changed keys are rejected.
 struct MetricsHandler {
     /// Hostname used for known_hosts lookup.
     host: String,
@@ -43,19 +44,49 @@ impl client::Handler for MetricsHandler {
         server_public_key: &russh::keys::key::PublicKey,
     ) -> Result<bool, Self::Error> {
         match russh::keys::check_known_hosts(&self.host, self.port, server_public_key) {
-            Ok(true) => Ok(true),  // key is in known_hosts and matches
-            Ok(false) => Ok(true), // host unknown — accept (first-connection semantics)
+            // Key is in known_hosts and matches.
+            Ok(true) => Ok(true),
+            // Host not seen before — record the key (trust on first use) so a
+            // later key change is detected, then accept. Recording is
+            // best-effort: a connection must not fail just because
+            // known_hosts is unwritable.
+            Ok(false) => {
+                match russh::keys::known_hosts::learn_known_hosts(
+                    &self.host,
+                    self.port,
+                    server_public_key,
+                ) {
+                    Ok(()) => tracing::info!(
+                        host = %self.host,
+                        port = self.port,
+                        "recorded new host key in known_hosts"
+                    ),
+                    Err(e) => tracing::warn!(
+                        host = %self.host,
+                        error = %e,
+                        "could not record host key in known_hosts"
+                    ),
+                }
+                Ok(true)
+            }
+            // A previously recorded key changed — refuse; possible MITM.
             Err(russh::keys::Error::KeyChanged { .. }) => {
                 tracing::warn!(
                     host = %self.host,
                     port = self.port,
-                    "Server key mismatch in known_hosts — possible MITM attack, refusing connection"
+                    "server key mismatch in known_hosts — possible MITM attack, refusing connection"
                 );
                 Ok(false)
             }
+            // Unreadable or corrupt known_hosts — fail closed rather than
+            // accept an unverified key.
             Err(e) => {
-                tracing::warn!(error = %e, "known_hosts check failed; accepting key");
-                Ok(true)
+                tracing::warn!(
+                    host = %self.host,
+                    error = %e,
+                    "known_hosts check failed; refusing connection"
+                );
+                Ok(false)
             }
         }
     }


### PR DESCRIPTION
- **Host keys are now verified**: A server's host key is recorded in `~/.ssh/known_hosts` on first connection (trust on first use). A later key change — or an unreadable `known_hosts` — refuses the connection instead of silently accepting an unverified key.
- **Password authentication reliably disabled**: Auto SSH Key Setup now adds the `PasswordAuthentication`, `UsePAM`, and challenge/keyboard-interactive directives when `sshd_config` omits them, so password login is disabled even on configs that previously relied on compiled-in defaults.
- **System SSH launch failure no longer quits the app**: If the `ssh` binary cannot be started, OmnySSH restores the TUI and reports the error in the status bar instead of exiting.
- **Remote command exit status honoured**: SSH command execution now exposes a non-zero remote exit status; the key-setup sudo check uses it to detect missing sudo access correctly.