### PR TITLE
Prune stale log files on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## 1.0.4 — 2026-05-29
+
+### Bug Fixes
+- **Log files no longer fill the disk**: On startup OmnySSH now prunes rolling log files older than 7 days from its config directory. The cleanup is best-effort and never blocks startup, works on every platform via the native config path, and only touches `omnyssh.log*` files — `config.toml`, `hosts.toml`, and `snippets.toml` are left untouched.
+
+---
+
 ## 1.0.3 — 2026-05-21
 
 ### Features

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,10 @@ async fn main() -> anyhow::Result<()> {
         eprintln!("Warning: Failed to create log directory: {}", e);
     }
 
+    // Prune stale rolling log files so they don't accumulate indefinitely.
+    let pruned_logs =
+        utils::platform::cleanup_old_logs(&log_dir, utils::platform::LOG_RETENTION_DAYS);
+
     // Use daily rolling file appender
     // IMPORTANT: _guard must live for the entire duration of the program.
     // If it's dropped, logs will stop being written to the file.
@@ -43,6 +47,10 @@ async fn main() -> anyhow::Result<()> {
         )
         .with_writer(non_blocking)
         .init();
+
+    if pruned_logs > 0 {
+        tracing::debug!("Pruned {} stale log file(s)", pruned_logs);
+    }
 
     // Restore the terminal if a panic occurs so the user is not left with a
     // broken shell.

--- a/src/utils/platform.rs
+++ b/src/utils/platform.rs
@@ -1,4 +1,11 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// Rolling log files older than this many days are pruned at startup.
+pub const LOG_RETENTION_DAYS: u64 = 7;
+
+/// Prefix shared by every rolling log file (`omnyssh.log`, `omnyssh.log.YYYY-MM-DD`).
+const LOG_FILE_PREFIX: &str = "omnyssh.log";
 
 /// Returns the path to the user's SSH config file.
 ///
@@ -31,4 +38,53 @@ pub fn hosts_config_path() -> Option<PathBuf> {
 /// Returns the path to the snippets config file.
 pub fn snippets_config_path() -> Option<PathBuf> {
     app_config_dir().map(|d| d.join("snippets.toml"))
+}
+
+/// Removes rolling log files in `log_dir` older than `max_age_days`.
+///
+/// Best-effort and fault-tolerant: a missing directory, an unreadable entry,
+/// or a failed delete is skipped rather than propagated, so log cleanup never
+/// blocks application startup. File age is taken from the filesystem
+/// modification time, which keeps the logic identical on every OS. Only files
+/// whose name starts with `omnyssh.log` are considered, so config and other
+/// data files in the same directory are never touched.
+///
+/// Returns the number of files removed.
+pub fn cleanup_old_logs(log_dir: &Path, max_age_days: u64) -> usize {
+    let entries = match std::fs::read_dir(log_dir) {
+        Ok(entries) => entries,
+        Err(_) => return 0,
+    };
+
+    let max_age = Duration::from_secs(max_age_days * 24 * 60 * 60);
+    let now = SystemTime::now();
+    let mut removed = 0;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+
+        let is_log_file = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.starts_with(LOG_FILE_PREFIX))
+            .unwrap_or(false);
+        if !is_log_file {
+            continue;
+        }
+
+        let modified = match entry.metadata().and_then(|meta| meta.modified()) {
+            Ok(modified) => modified,
+            Err(_) => continue,
+        };
+
+        // `duration_since` errors on files dated in the future (clock skew);
+        // treat those as recent and keep them.
+        if let Ok(age) = now.duration_since(modified) {
+            if age > max_age && std::fs::remove_file(&path).is_ok() {
+                removed += 1;
+            }
+        }
+    }
+
+    removed
 }

--- a/tests/log_cleanup.rs
+++ b/tests/log_cleanup.rs
@@ -1,0 +1,83 @@
+//! Tests for startup log pruning.
+//!
+//! Verifies that `cleanup_old_logs` removes only stale rolling log files,
+//! leaves recent logs and unrelated files untouched, and never panics on a
+//! missing directory.
+
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use omnyssh::utils::platform::cleanup_old_logs;
+
+/// Creates a unique, empty scratch directory under the system temp dir.
+fn scratch_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("omnyssh-test-{}-{}", tag, std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+/// Writes a file and backdates its modification time by `age_days`.
+fn write_aged(dir: &Path, name: &str, age_days: u64) {
+    let path = dir.join(name);
+    let file = File::create(&path).expect("create file");
+    let mtime = SystemTime::now() - Duration::from_secs(age_days * 24 * 60 * 60);
+    file.set_modified(mtime).expect("set mtime");
+}
+
+#[test]
+fn removes_logs_older_than_retention() {
+    let dir = scratch_dir("old");
+    write_aged(&dir, "omnyssh.log.2026-01-01", 30);
+    write_aged(&dir, "omnyssh.log.2026-01-02", 14);
+
+    let removed = cleanup_old_logs(&dir, 7);
+
+    assert_eq!(removed, 2);
+    assert!(!dir.join("omnyssh.log.2026-01-01").exists());
+    assert!(!dir.join("omnyssh.log.2026-01-02").exists());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn keeps_recent_logs() {
+    let dir = scratch_dir("recent");
+    write_aged(&dir, "omnyssh.log.2026-05-29", 0);
+    write_aged(&dir, "omnyssh.log.2026-05-25", 3);
+
+    let removed = cleanup_old_logs(&dir, 7);
+
+    assert_eq!(removed, 0);
+    assert!(dir.join("omnyssh.log.2026-05-29").exists());
+    assert!(dir.join("omnyssh.log.2026-05-25").exists());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn never_touches_non_log_files() {
+    let dir = scratch_dir("config");
+    write_aged(&dir, "config.toml", 90);
+    write_aged(&dir, "hosts.toml", 90);
+    write_aged(&dir, "snippets.toml", 90);
+    write_aged(&dir, "omnyssh.log.2026-01-01", 90);
+
+    let removed = cleanup_old_logs(&dir, 7);
+
+    assert_eq!(removed, 1);
+    assert!(dir.join("config.toml").exists());
+    assert!(dir.join("hosts.toml").exists());
+    assert!(dir.join("snippets.toml").exists());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn missing_directory_is_a_no_op() {
+    let dir = std::env::temp_dir().join("omnyssh-test-missing-does-not-exist");
+    let _ = fs::remove_dir_all(&dir);
+
+    assert_eq!(cleanup_old_logs(&dir, 7), 0);
+}


### PR DESCRIPTION
The daily rolling appender creates one `omnyssh.log.YYYY-MM-DD` file per day in the config directory and never cleans them up, so logs accumulate indefinitely and fill the disk over time.

This adds `cleanup_old_logs`, which runs once at startup and removes rolling log files older than 7 days. It is:

- **Cross-platform.** Operates on `dirs::config_dir()/omnyssh`, the same directory used on macOS, Linux, Termux, and Windows. Age is read from filesystem mtime, so the logic is identical everywhere.
- **Fault-tolerant.** A missing directory, unreadable entry, or failed delete is skipped rather than propagated, so cleanup can never block startup.
- **Safe.** Only files prefixed with `omnyssh.log` are considered; `config.toml`, `hosts.toml`, and `snippets.toml` are never touched.

Covered by 4 integration tests: old files removed, recent files kept, non-log files untouched, and missing directory is a no-op.
