### PR TITLE
Auto-supply the stored password to the terminal (no more password prompts)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,18 @@ mod utils;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // SSH_ASKPASS mode: the terminal's `ssh` child re-invokes us as its askpass
+    // helper for password-auth hosts (see `ssh::askpass`). Handle it before
+    // parsing CLI args — the prompt is passed as a positional argument that is
+    // not a valid omny flag — and before any TUI/logging setup.
+    if let Ok(password) = std::env::var(ssh::askpass::PASSWORD_ENV) {
+        let prompt = std::env::args().nth(1).unwrap_or_default();
+        if let Some(answer) = ssh::askpass::response_for_prompt(&prompt, &password) {
+            println!("{answer}");
+        }
+        return Ok(());
+    }
+
     let cli = cli::Cli::parse();
 
     // Initialise logging. Output goes to a log file instead of stderr to prevent

--- a/src/ssh/askpass.rs
+++ b/src/ssh/askpass.rs
@@ -1,0 +1,27 @@
+//! SSH_ASKPASS integration for password-auth terminal sessions.
+//!
+//! The interactive terminal spawns the system `ssh` binary, which cannot read
+//! the password stored in `hosts.toml` and therefore prompts for it on every
+//! connection. To avoid that, the terminal points `SSH_ASKPASS` at our own
+//! binary and passes the password through the child process environment (see
+//! [`PASSWORD_ENV`]). When `ssh` needs a password it re-invokes us in askpass
+//! mode and reads the answer from stdout — the password never touches disk or
+//! the command line.
+
+/// Environment variable carrying the stored password to our binary when it is
+/// invoked as `ssh`'s askpass helper. Its presence signals askpass mode.
+pub const PASSWORD_ENV: &str = "OMNY_ASKPASS_PASSWORD";
+
+/// Decides what to print when invoked as `ssh`'s askpass program.
+///
+/// `prompt` is the text `ssh` passes as the first argument. Returns
+/// `Some(password)` only for genuine password prompts; returns `None` for any
+/// other prompt (e.g. a host-key `yes/no` confirmation) so the password is
+/// never fed to a non-password question.
+pub fn response_for_prompt(prompt: &str, password: &str) -> Option<String> {
+    if prompt.to_lowercase().contains("password") {
+        Some(password.to_string())
+    } else {
+        None
+    }
+}

--- a/src/ssh/mod.rs
+++ b/src/ssh/mod.rs
@@ -4,6 +4,7 @@
 /// metrics collection, PTY-backed multi-session terminal emulator,
 /// Smart Server Context with service discovery, and Auto SSH Key Setup
 /// for secure authentication.
+pub mod askpass;
 pub mod client;
 pub mod discovery;
 pub mod key_setup;

--- a/src/ssh/pty.rs
+++ b/src/ssh/pty.rs
@@ -121,6 +121,22 @@ impl PtySession {
         }
         cmd.arg(format!("{}@{}", host.user, host.hostname));
 
+        // Password-auth hosts: hand the stored password to `ssh` via SSH_ASKPASS
+        // so the terminal connects without an interactive prompt. We point
+        // SSH_ASKPASS at our own binary (see `ssh::askpass` and main.rs) and pass
+        // the password through the child environment — never on disk or argv.
+        // `SSH_ASKPASS_REQUIRE=force` makes ssh use the helper even though a PTY
+        // is attached. Keys and the SSH agent are still tried first; the helper
+        // is only invoked when ssh actually needs a password. If `current_exe`
+        // is unavailable we skip this and fall back to the interactive prompt.
+        if let Some(ref password) = host.password {
+            if let Ok(exe) = std::env::current_exe() {
+                cmd.env("SSH_ASKPASS", exe);
+                cmd.env("SSH_ASKPASS_REQUIRE", "force");
+                cmd.env(crate::ssh::askpass::PASSWORD_ENV, password);
+            }
+        }
+
         // Spawn the child — slave is consumed and becomes the child's controlling TTY.
         let child = pair
             .slave

--- a/tests/askpass.rs
+++ b/tests/askpass.rs
@@ -1,0 +1,36 @@
+//! Tests for the SSH_ASKPASS prompt handling.
+//!
+//! The askpass helper must answer genuine password prompts with the stored
+//! password, but never feed the password to other prompts (e.g. a host-key
+//! `yes/no` confirmation).
+
+use omnyssh::ssh::askpass::response_for_prompt;
+
+#[test]
+fn answers_standard_password_prompt() {
+    let prompt = "user@host's password:";
+    assert_eq!(
+        response_for_prompt(prompt, "s3cret"),
+        Some("s3cret".to_string())
+    );
+}
+
+#[test]
+fn answers_capitalized_password_prompt() {
+    assert_eq!(
+        response_for_prompt("Password:", "s3cret"),
+        Some("s3cret".to_string())
+    );
+}
+
+#[test]
+fn ignores_host_key_confirmation_prompt() {
+    let prompt = "The authenticity of host 'example.com' can't be established.\n\
+                  Are you sure you want to continue connecting (yes/no/[fingerprint])?";
+    assert_eq!(response_for_prompt(prompt, "s3cret"), None);
+}
+
+#[test]
+fn ignores_empty_prompt() {
+    assert_eq!(response_for_prompt("", "s3cret"), None);
+}


### PR DESCRIPTION
Hosts configured with password authentication worked fine for metrics, quick-commands, and snippets (which use the russh client and fall back to the stored password), but the interactive terminal spawns the system ssh binary, which can't read the stored password and prompted for it on every connection.

This wires the stored password into the terminal's ssh child through `SSH_ASKPASS`:

- The terminal points `SSH_ASKPASS` at the omny binary itself and sets `SSH_ASKPASS_REQUIRE=force`, passing the password via the child's environment (`OMNY_ASKPASS_PASSWORD`).
- When ssh needs a password it re-invokes omny in askpass mode; omny prints the password and exits.
- Keys and the SSH agent are still tried first. The helper is only invoked when ssh actually asks for a password. Hosts without a stored password are unchanged.

**Security:** The password is only ever passed through the child process environment (it already lives in plaintext in `hosts.toml`). It is never written to disk, never on the command line / ps, and never sent to the remote. The askpass helper answers genuine password prompts only; it never feeds the password to a host-key yes/no confirmation. Requires OpenSSH 8.4+ (modern macOS/Linux/Termux); if `current_exe` is unavailable it falls back to the old interactive prompt.

Covered by 4 tests for the prompt-discrimination logic.

