### PR TITLE
docs: fix verbose stderr/log, install config path, split keybind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - **Log files no longer fill the disk**: On startup OmnySSH now prunes rolling log files older than 7 days from its config directory. The cleanup is best-effort and never blocks startup, works on every platform via the native config path, and only touches `omnyssh.log*` files — `config.toml`, `hosts.toml`, and `snippets.toml` are left untouched.
 - **Man page now installs reliably**: `install.sh` failed to install the man page into the system directory (e.g. `/usr/local/share/man` on macOS) because it never elevated with `sudo`, so `man omny` reported "No manual entry". The man page is now downloaded to a temp file first and installed with a `sudo` fallback, mirroring the binary install.
 
+### Documentation
+- Fixed inaccurate docs: `--verbose` now correctly states logs are written to a log file (not stderr) in `--help`, the man page, and the README; `install.sh` prints the OS-specific config directory; corrected the horizontal split keybinding in the changelog (`Ctrl+]`, not `Ctrl+-`).
+
 ### Other
 - Removed the vestigial empty `package.json` and `package-lock.json` (left over from an earlier project name); they served no purpose in this Rust project.
 
@@ -111,7 +114,7 @@ First production-ready release of OmnySSH.
 
 #### Multi-session terminal
 - PTY-backed terminal with tabs (`Ctrl+T` / `Ctrl+W`)
-- Split-view: `Ctrl+\` vertical, `Ctrl+-` horizontal
+- Split-view: `Ctrl+\` vertical, `Ctrl+]` horizontal
 - Tab navigation with `Ctrl+Right` / `Ctrl+Left`
 - Activity indicator on tabs with unseen output
 - Full VT100 terminal emulation (`portable-pty` + `vt100`)

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ omny [OPTIONS]
 Options:
   -c, --config <FILE>   Path to a custom config file
   -t, --theme <THEME>   Override the color theme (default | dracula | nord | gruvbox)
-  -v, --verbose         Enable debug logging (written to stderr)
+  -v, --verbose         Enable debug logging (written to a log file)
   -h, --help            Print help
   -V, --version         Print version
 ```

--- a/doc/omny.1
+++ b/doc/omny.1
@@ -20,7 +20,7 @@ Override the color theme (default | dracula | nord | gruvbox).
 This overrides the theme setting from the config file.
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
-Enable verbose debug logging (written to stderr)
+Enable verbose debug logging (written to a log file in the config directory)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/install.sh
+++ b/install.sh
@@ -290,9 +290,15 @@ main() {
     echo ""
     print_success "Installation complete!"
     echo ""
+    case "$PLATFORM" in
+        apple-darwin)    CONFIG_DIR="~/Library/Application Support/omnyssh/" ;;
+        pc-windows-msvc) CONFIG_DIR="%APPDATA%\\omnyssh\\" ;;
+        *)               CONFIG_DIR="~/.config/omnyssh/" ;;
+    esac
+
     print_info "Next steps:"
     print_info "  1. Run 'omny' to start the application"
-    print_info "  2. Configure your servers in ~/.config/omnyssh/"
+    print_info "  2. Configure your servers in $CONFIG_DIR"
     print_info "  3. Check 'man omny' for documentation (Linux/macOS)"
     print_info "  4. Visit https://github.com/$REPO for more info"
     echo ""

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ pub struct Cli {
     #[arg(short, long, value_name = "THEME")]
     pub theme: Option<String>,
 
-    /// Enable verbose debug logging (written to stderr).
+    /// Enable verbose debug logging (written to a log file in the config directory).
     #[arg(short, long)]
     pub verbose: bool,
 }


### PR DESCRIPTION
- Fixed inaccurate docs: `--verbose` now correctly states logs are written to a log file (not stderr) in `--help`, the man page, and the README; `install.sh` prints the OS-specific config directory; corrected the horizontal split keybinding in the changelog (`Ctrl+]`, not `Ctrl+-`).