### PR TITLE
fix: security audit findings, bug fixes, and CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e18c1f174b91b07 # stable
         with:
           components: clippy, rustfmt
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e18c1f174b91b07 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy, rustfmt
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
     name: CI checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e18c1f174b91b07 # stable
         with:
           components: clippy, rustfmt
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -85,13 +85,13 @@ jobs:
             archive: omny-x86_64-pc-windows-msvc.zip
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e18c1f174b91b07 # stable
         with:
           targets: ${{ matrix.target }}
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -134,7 +134,7 @@ jobs:
 
       # Upload the archive as an artifact — the publish job downloads it
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.archive }}
           path: ${{ matrix.archive }}
@@ -150,11 +150,11 @@ jobs:
       contents: write   # required to create the Release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       # Download all four archives from the previous jobs
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
           merge-multiple: true
@@ -187,7 +187,7 @@ jobs:
 
       # Create the Release and attach all binaries in one step
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8f3c11 # v2
         with:
           name: OmnySSH ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.body }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e18c1f174b91b07 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy, rustfmt
 
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e18c1f174b91b07 # stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 
@@ -187,7 +187,7 @@ jobs:
 
       # Create the Release and attach all binaries in one step
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8f3c11 # v2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
           name: OmnySSH ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.body }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,20 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ### Features
 - **Terminal no longer prompts for the password on password-auth hosts**: When a host is configured with a stored password, the interactive terminal now supplies it automatically via `SSH_ASKPASS` instead of asking on every connection (metrics, quick-commands, and snippets already did this). Keys and the SSH agent are still tried first; the password is only used as a fallback. The password is passed to `ssh` through the child process environment — never written to disk, shown on the command line, or sent to the remote.
 
+### Security
+- Validate public-key format and reject control characters before embedding keys in remote shell commands.
+- Sanitize `sshd_config` directive edits and scope the disabled `Include` to the cloud-init drop-in only.
+- Store `config.toml`, `hosts.toml`, and `snippets.toml` with `0600` permissions, and remove temp files left by a failed save.
+- Reject `..` traversal and null bytes in SFTP upload/download paths.
+- Pin all GitHub Actions to commit SHAs and verify release archives against `SHA256SUMS` in `install.sh` (with a `shasum` fallback on macOS).
+
 ### Bug Fixes
 - **Log files no longer fill the disk**: On startup OmnySSH now prunes rolling log files older than 7 days from its config directory. The cleanup is best-effort and never blocks startup, works on every platform via the native config path, and only touches `omnyssh.log*` files — `config.toml`, `hosts.toml`, and `snippets.toml` are left untouched.
 - **Man page now installs reliably**: `install.sh` failed to install the man page into the system directory (e.g. `/usr/local/share/man` on macOS) because it never elevated with `sudo`, so `man omny` reported "No manual entry". The man page is now downloaded to a temp file first and installed with a `sudo` fallback, mirroring the binary install.
+- **Remote command exit status is no longer lost** when it arrives after EOF.
+- **Multi-file deletes fixed**: all in-flight remote deletes are tracked before the panel refreshes, and every error from a multi-file local delete is reported.
+- **Terminal is always restored on exit**, even if an earlier teardown step fails.
+- **Docker view scales to many containers**: `docker inspect` is batched to stay under `ARG_MAX`.
 
 ### Documentation
 - Fixed inaccurate docs: `--verbose` now correctly states logs are written to a log file (not stderr) in `--help`, the man page, and the README; `install.sh` prints the OS-specific config directory; corrected the horizontal split keybinding in the changelog (`Ctrl+]`, not `Ctrl+-`).
@@ -25,6 +36,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - Removed the unused `config/default.toml` template — it was never read by the app, and the README already carries the canonical config example.
 - CI now fails if the committed `doc/omny.1` man page drifts from `src/cli.rs`, so the generated man page can no longer go stale.
 - Removed dead code with no effect on runtime behaviour: unused functions with no callers (`Screen::title`, `Host::id`, `key_path_for_host`, the superseded `host_list` render path, and two unused popup renderers), plus three methods that were only reachable from their own tests (`FileManagerPanel::clamp_scroll`, `ProbeOutput::section_names`, `KeySetupMachine::password_disabled`) and those tests.
+- Made the `sshd` rollback backup lookup portable so it also works on BusyBox/Alpine hosts.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -153,6 +153,20 @@ download_and_install() {
         exit 1
     fi
 
+    # Verify download integrity
+    SHA_URL="https://github.com/$REPO/releases/download/$VERSION/SHA256SUMS"
+    echo "Verifying checksum..."
+    if curl -fsSL "$SHA_URL" -o "$TMP_DIR/SHA256SUMS" 2>/dev/null; then
+        (cd "$TMP_DIR" && grep "${ARCHIVE_NAME}.${ARCHIVE_EXT}" SHA256SUMS | sha256sum -c -) || {
+            echo "ERROR: Checksum verification failed!"
+            rm -rf "$TMP_DIR"
+            exit 1
+        }
+        echo "Checksum verified ✓"
+    else
+        echo "WARNING: Could not download SHA256SUMS — skipping verification"
+    fi
+
     print_info "Extracting archive..."
 
     # Extract based on archive type
@@ -241,7 +255,7 @@ install_man_page() {
 
     print_info "Installing man page..."
 
-    MAN_URL="https://raw.githubusercontent.com/$REPO/main/doc/omny.1"
+    MAN_URL="https://raw.githubusercontent.com/$REPO/$VERSION/doc/omny.1"
     if [ "$IS_TERMUX" = "1" ]; then
         MAN_DIR="$PREFIX/share/man/man1"
     else

--- a/install.sh
+++ b/install.sh
@@ -156,8 +156,18 @@ download_and_install() {
     # Verify download integrity
     SHA_URL="https://github.com/$REPO/releases/download/$VERSION/SHA256SUMS"
     echo "Verifying checksum..."
-    if curl -fsSL "$SHA_URL" -o "$TMP_DIR/SHA256SUMS" 2>/dev/null; then
-        (cd "$TMP_DIR" && grep "${ARCHIVE_NAME}.${ARCHIVE_EXT}" SHA256SUMS | sha256sum -c -) || {
+    # Pick whichever checksum tool is present: sha256sum on Linux, shasum on macOS.
+    if command -v sha256sum >/dev/null 2>&1; then
+        SHA_CHECK="sha256sum -c -"
+    elif command -v shasum >/dev/null 2>&1; then
+        SHA_CHECK="shasum -a 256 -c -"
+    else
+        SHA_CHECK=""
+    fi
+    if [ -z "$SHA_CHECK" ]; then
+        echo "WARNING: no sha256 tool found — skipping verification"
+    elif curl -fsSL "$SHA_URL" -o "$TMP_DIR/SHA256SUMS" 2>/dev/null; then
+        (cd "$TMP_DIR" && grep "${ARCHIVE_NAME}.${ARCHIVE_EXT}" SHA256SUMS | $SHA_CHECK) || {
             echo "ERROR: Checksum verification failed!"
             rm -rf "$TMP_DIR"
             exit 1

--- a/src/app/file_manager.rs
+++ b/src/app/file_manager.rs
@@ -469,6 +469,8 @@ impl App {
         let is_remote = self.view.file_manager.active_panel == FmPanel::Remote;
 
         if is_remote {
+            // Track how many ops are in flight so SftpOpDone can count down.
+            self.view.file_manager.pending_ops = paths.len();
             // Send delete commands for all paths.
             for path in paths {
                 if let Some(mgr) = &self.sftp_manager {
@@ -478,23 +480,28 @@ impl App {
         } else {
             let tx = self.event_tx.clone();
             tokio::spawn(async move {
-                let mut last_err: Option<String> = None;
+                let mut errors: Vec<String> = Vec::new();
                 for path in paths {
-                    let result = tokio::fs::remove_file(&path).await.or_else(|_| {
-                        // Might be a directory — try remove_dir (empty only).
-                        // Using blocking version since remove_dir_all is destructive.
-                        std::fs::remove_dir(&path)
-                            .map_err(|e| std::io::Error::new(e.kind(), e.to_string()))
-                    });
+                    let result = match tokio::fs::remove_file(&path).await {
+                        Ok(()) => Ok(()),
+                        Err(_) => {
+                            // Might be a directory — try remove_dir (empty only).
+                            tokio::fs::remove_dir(&path).await
+                        }
+                    };
                     if let Err(e) = result {
-                        last_err = Some(e.to_string());
+                        errors.push(format!("{path}: {e}"));
                     }
                 }
-                let result = last_err.map_or(Ok(()), Err);
+                let result = if errors.is_empty() {
+                    Ok(())
+                } else {
+                    Err(errors.join("; "))
+                };
                 let _ = tx
                     .send(AppEvent::SftpOpDone {
                         kind: SftpOpKind::Delete,
-                        result: result.map_err(|e: String| e),
+                        result,
                     })
                     .await;
             });

--- a/src/app/host.rs
+++ b/src/app/host.rs
@@ -1,10 +1,7 @@
 //! Host list state: add/edit form, list view, popups, and the `App` methods
 //! that create, update, delete, and connect to hosts.
 
-use std::io::Stdout;
 use std::time::Duration;
-
-use ratatui::{backend::CrosstermBackend, Terminal};
 
 use super::*;
 use crate::ssh::client::HostSource;
@@ -239,8 +236,6 @@ pub struct HostListView {
     pub filtered_indices: Vec<usize>,
     /// Currently visible popup (if any).
     pub popup: Option<HostPopup>,
-    /// Host waiting to be connected (handled before the next render).
-    pub pending_connect: Option<Host>,
     // Dashboard additions -----------
     /// Active sort order for the dashboard grid.
     pub sort_order: SortOrder,
@@ -551,82 +546,6 @@ impl App {
             self.view.status_message = Some(format!("Save failed: {e}"));
         }
     }
-
-    /// Temporarily restores the terminal, runs the system SSH binary for the
-    /// given host, then re-initialises the TUI.
-    pub(crate) async fn connect_system_ssh(
-        &mut self,
-        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
-        host: &Host,
-    ) -> anyhow::Result<()> {
-        // 1. Leave TUI mode.
-        leave_tui()?;
-
-        // 2. Build SSH command (ConnectTimeout=10).
-        let mut cmd = tokio::process::Command::new("ssh");
-        cmd.args(["-o", "ConnectTimeout=10"]);
-        if host.port != 22 {
-            cmd.args(["-p", &host.port.to_string()]);
-        }
-        if let Some(ref key) = host.identity_file {
-            cmd.args(["-i", key]);
-        }
-        if let Some(ref jump) = host.proxy_jump {
-            cmd.args(["-J", jump]);
-        }
-        cmd.arg(format!("{}@{}", host.user, host.hostname));
-
-        // 3. Hand off terminal control to SSH. A spawn/wait failure (e.g. no
-        //    `ssh` binary on PATH) must not abort the app — the TUI is still
-        //    restored below and the error is shown in the status bar.
-        tracing::info!("Connecting to {} via system SSH", host.name);
-        let outcome = match cmd.spawn() {
-            Ok(mut child) => child.wait().await,
-            Err(e) => Err(e),
-        };
-
-        // 4. Re-enter TUI mode. Bracketed paste is re-enabled here because the
-        // remote shell may have left it disabled when the SSH session ended.
-        enter_tui()?;
-        terminal.clear()?;
-
-        // 5. Show connection result.
-        self.view.status_message = Some(match outcome {
-            Ok(status) if status.success() => format!("Disconnected from '{}'.", host.name),
-            Ok(status) => format!(
-                "SSH to '{}' exited with code {:?}.",
-                host.name,
-                status.code()
-            ),
-            Err(e) => format!("Failed to launch ssh for '{}': {e}", host.name),
-        });
-
-        Ok(())
-    }
-}
-
-/// Leaves the omnyssh TUI so a child process can own the terminal.
-fn leave_tui() -> anyhow::Result<()> {
-    crossterm::terminal::disable_raw_mode()?;
-    crossterm::execute!(
-        std::io::stdout(),
-        crossterm::terminal::LeaveAlternateScreen,
-        crate::utils::mouse::DisableMinimalMouseCapture,
-        crossterm::event::DisableBracketedPaste,
-    )?;
-    Ok(())
-}
-
-/// Re-enters the omnyssh TUI after a child process has exited.
-fn enter_tui() -> anyhow::Result<()> {
-    crossterm::terminal::enable_raw_mode()?;
-    crossterm::execute!(
-        std::io::stdout(),
-        crossterm::terminal::EnterAlternateScreen,
-        crate::utils::mouse::EnableMinimalMouseCapture,
-        crossterm::event::EnableBracketedPaste,
-    )?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -331,14 +331,17 @@ impl App {
         }
 
         // Terminal restore — always runs even if main_loop returned Err.
-        crossterm::terminal::disable_raw_mode()?;
-        crossterm::execute!(
+        // Each step runs unconditionally so a failure in one does not prevent
+        // the remaining steps from executing.
+        let r1 = crossterm::terminal::disable_raw_mode();
+        let r2 = crossterm::execute!(
             terminal.backend_mut(),
             crossterm::terminal::LeaveAlternateScreen,
             crate::utils::mouse::DisableMinimalMouseCapture,
             crossterm::event::DisableBracketedPaste,
-        )?;
-        terminal.show_cursor()?;
+        );
+        let r3 = terminal.show_cursor();
+        r1.and(r2).and(r3)?;
 
         result
     }
@@ -349,15 +352,6 @@ impl App {
         terminal: &mut Terminal<CrosstermBackend<Stdout>>,
     ) -> anyhow::Result<()> {
         loop {
-            // ----------------------------------------------------------------
-            // Handle a pending SSH connection *before* the next render so the
-            // terminal is fully restored while SSH runs.
-            // ----------------------------------------------------------------
-            if let Some(host) = self.view.host_list.pending_connect.take() {
-                self.connect_system_ssh(terminal, &host).await?;
-                continue;
-            }
-
             // ----------------------------------------------------------------
             // Render.
             // ----------------------------------------------------------------

--- a/src/config/app_config.rs
+++ b/src/config/app_config.rs
@@ -415,6 +415,12 @@ fn persist_config<F: FnOnce(&mut AppConfig)>(mutator: F) -> anyhow::Result<()> {
     let content = toml::to_string_pretty(&config).context("Failed to serialize config")?;
     std::fs::write(&config_path, content)
         .with_context(|| format!("Failed to write config: {}", config_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        let _ = std::fs::set_permissions(&config_path, perms);
+    }
 
     Ok(())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -81,13 +81,22 @@ pub fn save_hosts(hosts: &[Host]) -> anyhow::Result<()> {
     let tmp_path = path.with_extension("toml.tmp");
     std::fs::write(&tmp_path, content)
         .with_context(|| format!("Failed to write {}", tmp_path.display()))?;
-    std::fs::rename(&tmp_path, &path).with_context(|| {
-        format!(
-            "Failed to rename {} to {}",
-            tmp_path.display(),
-            path.display()
-        )
-    })?;
+    if let Err(e) = std::fs::rename(&tmp_path, &path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e).with_context(|| {
+            format!(
+                "Failed to rename {} to {}",
+                tmp_path.display(),
+                path.display()
+            )
+        });
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        let _ = std::fs::set_permissions(&path, perms);
+    }
 
     Ok(())
 }

--- a/src/config/snippets.rs
+++ b/src/config/snippets.rs
@@ -79,13 +79,22 @@ pub fn save_snippets(snippets: &[Snippet]) -> anyhow::Result<()> {
     let tmp_path = path.with_extension("toml.tmp");
     std::fs::write(&tmp_path, &content)
         .with_context(|| format!("Failed to write {}", tmp_path.display()))?;
-    std::fs::rename(&tmp_path, &path).with_context(|| {
-        format!(
-            "Failed to rename {} to {}",
-            tmp_path.display(),
-            path.display()
-        )
-    })?;
+    if let Err(e) = std::fs::rename(&tmp_path, &path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e).with_context(|| {
+            format!(
+                "Failed to rename {} to {}",
+                tmp_path.display(),
+                path.display()
+            )
+        });
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        let _ = std::fs::set_permissions(&path, perms);
+    }
 
     Ok(())
 }

--- a/src/ssh/key_setup.rs
+++ b/src/ssh/key_setup.rs
@@ -381,6 +381,18 @@ pub fn sanitize_hostname(hostname: &str) -> String {
 /// The command creates ~/.ssh if it doesn't exist, appends the key (never overwrites),
 /// and sets correct permissions.
 pub fn build_authorized_keys_command(public_key: &str) -> String {
+    // Validate public key is a single line matching expected SSH format.
+    let public_key = public_key.trim();
+    if public_key.contains('\n') || public_key.contains('\r') || public_key.contains('\0') {
+        panic!("Public key file contains invalid characters");
+    }
+    if !public_key.starts_with("ssh-ed25519 ")
+        && !public_key.starts_with("ssh-rsa ")
+        && !public_key.starts_with("ecdsa-sha2-")
+    {
+        panic!("Public key file has unrecognized key type");
+    }
+
     // Escape single quotes in the public key.
     let escaped_key = public_key.replace('\'', "'\\''");
 
@@ -429,7 +441,7 @@ pub fn build_disable_password_command() -> String {
     format!(
         r#"sudo -n true 2>/dev/null || {{ echo "OMNYSSH_NO_SUDO"; exit 1; }}; \
            sudo cp /etc/ssh/sshd_config /etc/ssh/sshd_config.omnyssh_backup.{timestamp} && \
-           sudo sed -i.bak 's/^Include\s/#Include /' /etc/ssh/sshd_config && \
+           sudo sed -i.bak 's|^Include /etc/ssh/sshd_config.d/|#Include /etc/ssh/sshd_config.d/|' /etc/ssh/sshd_config && \
            {password} && \
            {challenge} && \
            {kbd} && \
@@ -444,6 +456,18 @@ pub fn build_disable_password_command() -> String {
 /// desired value; then, if the file had none, prepends the directive so it
 /// becomes the first global occurrence sshd reads.
 fn force_sshd_directive(directive: &str, value: &str) -> String {
+    assert!(
+        directive
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+        "directive contains unsafe characters: {directive}"
+    );
+    assert!(
+        value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == ' '),
+        "value contains unsafe characters: {value}"
+    );
     format!(
         r#"sudo sed -i.bak 's/^#\?{directive}.*/{directive} {value}/' /etc/ssh/sshd_config && \
            {{ sudo grep -qE '^{directive}[[:space:]]' /etc/ssh/sshd_config || \
@@ -469,7 +493,7 @@ pub fn build_reload_sshd_command() -> String {
 ///
 /// Restores the most recent OmnySSH backup of sshd_config and reloads the daemon.
 pub fn build_rollback_command() -> String {
-    r#"BACKUP=$(ls -t /etc/ssh/sshd_config.omnyssh_backup.* 2>/dev/null | head -1); \
+    r#"BACKUP=$(find /etc/ssh -maxdepth 1 -name 'sshd_config.omnyssh_backup.*' -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-); \
        if [ -n "$BACKUP" ]; then \
            sudo cp "$BACKUP" /etc/ssh/sshd_config && \
            (sudo systemctl reload sshd 2>/dev/null || sudo systemctl reload ssh 2>/dev/null || sudo service sshd reload 2>/dev/null || sudo service ssh reload); \
@@ -581,6 +605,21 @@ async fn setup_key_internal(
     let public_key_content = tokio::fs::read_to_string(&public_key_path)
         .await
         .context("Failed to read public key file")?;
+
+    // Validate public key format before embedding in shell command.
+    let public_key_trimmed = public_key_content.trim();
+    if public_key_trimmed.contains('\n')
+        || public_key_trimmed.contains('\r')
+        || public_key_trimmed.contains('\0')
+    {
+        anyhow::bail!("Public key file contains invalid characters");
+    }
+    if !public_key_trimmed.starts_with("ssh-ed25519 ")
+        && !public_key_trimmed.starts_with("ssh-rsa ")
+        && !public_key_trimmed.starts_with("ecdsa-sha2-")
+    {
+        anyhow::bail!("Public key file has unrecognized key type");
+    }
 
     let copy_cmd = build_authorized_keys_command(&public_key_content);
     match time::timeout(STEP_TIMEOUT, password_session.run_command(&copy_cmd)).await {
@@ -906,8 +945,10 @@ mod tests {
         assert!(cmd.contains("omnyssh_backup."));
         // Should run sshd -t for validation.
         assert!(cmd.contains("sshd -t"));
-        // Should comment out Include directives to prevent overrides.
-        assert!(cmd.contains("'s/^Include\\s/#Include /'"));
+        // Should comment out cloud-init Include directive to prevent overrides.
+        assert!(
+            cmd.contains("'s|^Include /etc/ssh/sshd_config.d/|#Include /etc/ssh/sshd_config.d/|'")
+        );
         // Should disable all password auth methods.
         assert!(cmd.contains("PasswordAuthentication no"));
         assert!(cmd.contains("ChallengeResponseAuthentication no"));

--- a/src/ssh/key_setup.rs
+++ b/src/ssh/key_setup.rs
@@ -493,7 +493,7 @@ pub fn build_reload_sshd_command() -> String {
 ///
 /// Restores the most recent OmnySSH backup of sshd_config and reloads the daemon.
 pub fn build_rollback_command() -> String {
-    r#"BACKUP=$(find /etc/ssh -maxdepth 1 -name 'sshd_config.omnyssh_backup.*' -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-); \
+    r#"BACKUP=$(find /etc/ssh -maxdepth 1 -name 'sshd_config.omnyssh_backup.*' 2>/dev/null | sort | tail -1); \
        if [ -n "$BACKUP" ]; then \
            sudo cp "$BACKUP" /etc/ssh/sshd_config && \
            (sudo systemctl reload sshd 2>/dev/null || sudo systemctl reload ssh 2>/dev/null || sudo service sshd reload 2>/dev/null || sudo service ssh reload); \

--- a/src/ssh/services/docker.rs
+++ b/src/ssh/services/docker.rs
@@ -68,7 +68,7 @@ docker stats --no-stream --format '{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}' 2>/de
 echo "===COMPOSE==="
 docker compose ls --format json 2>/dev/null || echo "[]"
 echo "===RESTARTS==="
-docker inspect --format '{{.Name}}\t{{.RestartCount}}' $(docker ps -aq) 2>/dev/null
+docker ps -aq 2>/dev/null | xargs -r -n 50 docker inspect --format '{{.Name}}\t{{.RestartCount}}' 2>/dev/null
 "#,
             )
             .await?;

--- a/src/ssh/session.rs
+++ b/src/ssh/session.rs
@@ -51,6 +51,11 @@ impl client::Handler for MetricsHandler {
             // best-effort: a connection must not fail just because
             // known_hosts is unwritable.
             Ok(false) => {
+                tracing::warn!(
+                    host = %self.host,
+                    port = self.port,
+                    "Accepting unknown host key for {} (Trust On First Use)", self.host
+                );
                 match russh::keys::known_hosts::learn_known_hosts(
                     &self.host,
                     self.port,
@@ -302,7 +307,6 @@ fn default_key_paths() -> Vec<std::path::PathBuf> {
         "id_ecdsa",
         "id_ecdsa_sk",
         "id_ed25519_sk",
-        "id_dsa",
     ]
     .iter()
     .map(|name| ssh.join(name))
@@ -392,7 +396,10 @@ async fn collect_output(
                 // before the channel is closed.
                 exit_status = Some(code);
             }
-            Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => break,
+            Some(ChannelMsg::Eof) => {
+                // Continue reading — ExitStatus may arrive after Eof.
+            }
+            Some(ChannelMsg::Close) | None => break,
             _ => {}
         }
     }

--- a/src/ssh/sftp.rs
+++ b/src/ssh/sftp.rs
@@ -132,7 +132,7 @@ impl SftpManager {
                     host_name: host_name.clone(),
                 })
                 .await;
-            sftp_task_loop(session, sftp, cmd_rx, event_tx.clone()).await;
+            sftp_task_loop(session, sftp, cmd_rx, event_tx.clone(), host_name.clone()).await;
             tracing::info!("SFTP task for '{}' exited", host_name);
         });
 
@@ -159,6 +159,7 @@ async fn sftp_task_loop(
     sftp: russh_sftp::client::SftpSession,
     mut cmd_rx: mpsc::Receiver<SftpCommand>,
     event_tx: mpsc::Sender<AppEvent>,
+    host_name: String,
 ) {
     while let Some(cmd) = cmd_rx.recv().await {
         match cmd {
@@ -171,7 +172,7 @@ async fn sftp_task_loop(
                 Err(e) => {
                     let _ = event_tx
                         .send(AppEvent::SftpDisconnected {
-                            host_name: String::new(),
+                            host_name: host_name.clone(),
                             reason: format!("ListDir failed: {e}"),
                         })
                         .await;
@@ -345,6 +346,9 @@ async fn do_download(
     {
         anyhow::bail!("Download destination path contains '..': {local}");
     }
+    if local.contains('\0') || remote.contains('\0') {
+        anyhow::bail!("Path contains null bytes");
+    }
 
     // Fetch size for progress (best-effort).
     let total = sftp
@@ -392,6 +396,17 @@ async fn do_upload(
     transfer_id: TransferId,
     event_tx: &mpsc::Sender<AppEvent>,
 ) -> anyhow::Result<()> {
+    // Guard against path traversal in the local source.
+    if std::path::Path::new(local)
+        .components()
+        .any(|c| c == std::path::Component::ParentDir)
+    {
+        anyhow::bail!("Upload source path contains '..': {local}");
+    }
+    if local.contains('\0') || remote.contains('\0') {
+        anyhow::bail!("Path contains null bytes");
+    }
+
     let mut local_file = tokio::fs::File::open(local)
         .await
         .context("open local file for upload")?;


### PR DESCRIPTION
## Summary

Community security audit and code review covering shell injection, config file permissions, SFTP path validation, CI supply chain, and several functional bugs.

**Security fixes:**
- Validate public key format before embedding in shell commands (prevents injection via crafted key comments)
- Add input validation to `force_sshd_directive()` to prevent sed injection
- Narrow `Include` directive commenting to cloud-init only (avoids disabling legitimate sshd security policies)
- Set 0600 permissions on config files that may contain credentials
- Thread host_name through SFTP task loop (was sending empty string in disconnect events)
- Add null byte and path traversal guards to SFTP upload/download

**Bug fixes:**
- Fix `collect_output` to continue reading after `Eof` so `ExitStatus` is not lost
- Set `pending_ops` for multi-file remote delete (progress popup was closing after first file)
- Collect all local delete errors instead of only the last one
- Replace blocking `std::fs::remove_dir` with `tokio::fs::remove_dir` in async context
- Make terminal restore unconditional (all steps run even if `disable_raw_mode` fails)
- Remove dead `pending_connect`/`connect_system_ssh` code path
- Batch `docker inspect` with `xargs -n 50` to avoid `ARG_MAX` with many containers

**CI/supply chain:**
- Pin all GitHub Actions to immutable commit SHAs
- Add SHA256SUMS verification to `install.sh`
- Fetch man page from tagged release commit instead of mutable `main` branch

**Crypto hardening:**
- Remove `id_dsa` from default key paths (DSA is broken, removed from OpenSSH 9.8)
- Add TOFU warning log when accepting unknown host keys

**Not included in this PR (discussed in issues, need maintainer input):**
- Askpass env var → pipe/socket (#35) — architectural change
- Snippet parameter shell escaping (#32) — behavior change pinned by existing test
- Self-update signature verification (#33) — needs release infrastructure
- `unsafe impl Send` → Mutex (#36) — performance implications need profiling

## Test plan

- [x] `cargo test` — all 26 tests pass
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean

## Related issues

Refs #32, #33, #34, #35, #36