### PR TITLE
chore(nix): update flake to use crane for workspace builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .claude
 demo.tape
 .DS_Store
+
+# Local symlink created by `nix build`.
+/result

--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ cargo build --release
 
 ### ❄️ Nix (Flakes)
 
-A `flake.nix` is provided for [Nix](https://nixos.org/) users. Requires flakes
-enabled (`experimental-features = nix-command flakes` in `~/.config/nix/nix.conf`).
+A `flake.nix` is provided for [Nix](https://nixos.org/) users who want a
+reproducible build, app entry point, and development shell. Enable flakes first
+if your Nix installation does not already do so
+(`experimental-features = nix-command flakes` in `~/.config/nix/nix.conf`).
 
 **Run without installing:**
 
@@ -180,10 +182,21 @@ nix develop            # drops you into a shell with rustc, cargo, clippy,
 cargo build
 ```
 
-The flake exposes `packages.default` (the `omny` binary plus man page),
-`apps.default` (for `nix run`), and `devShells.default`. It evaluates
-cleanly across `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, and
-`aarch64-darwin`.
+**Validate the flake:**
+
+```bash
+nix flake check        # builds, formats, lints, and tests the workspace
+```
+
+The flake exposes:
+
+- `packages.default` and `packages.omnyssh` for the `omny` binary plus man page
+- `apps.default` for `nix run`
+- `checks` for the package build, rustfmt, clippy, and workspace tests
+- `devShells.default` for day-to-day Rust development
+
+It evaluates cleanly across `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`,
+and `aarch64-darwin`.
 
 ---
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -20,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777268161,
-        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {
@@ -36,6 +51,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,62 +4,102 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    crane.url = "github:ipetkov/crane";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      crane,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs { inherit system; };
+        craneLib = crane.mkLib pkgs;
 
-        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        workspaceToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        crateToml = builtins.fromTOML (builtins.readFile ./crates/omnyssh/Cargo.toml);
 
-        omnyssh = pkgs.rustPlatform.buildRustPackage {
-          pname = cargoToml.package.name;
-          version = cargoToml.package.version;
+        workspacePackage = workspaceToml.workspace.package;
+        cratePackage = crateToml.package;
+        pname = cratePackage.name;
+        inherit (workspacePackage) version;
+        src = craneLib.cleanCargoSource ./.;
 
-          src = self;
+        commonArgs = {
+          inherit pname version src;
 
-          cargoLock = {
-            lockFile = ./Cargo.lock;
-          };
-
-          nativeBuildInputs = [ pkgs.pkg-config pkgs.installShellFiles ];
-
-          postInstall = ''
-            installManPage doc/omny.1
-          '';
-
-          meta = with pkgs.lib; {
-            description = cargoToml.package.description;
-            homepage = cargoToml.package.repository;
-            license = licenses.asl20;
-            mainProgram = "omny";
-          };
+          strictDeps = true;
+          nativeBuildInputs = [ pkgs.pkg-config ];
         };
+
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+        omnyssh = craneLib.buildPackage (
+          commonArgs
+          // {
+            inherit cargoArtifacts;
+
+            cargoBuildExtraArgs = "--package ${pname}";
+            doCheck = false;
+
+            nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.installShellFiles ];
+
+            postInstall = ''
+              installManPage doc/omny.1
+            '';
+
+            meta = with pkgs.lib; {
+              inherit (cratePackage) description;
+              homepage = workspacePackage.repository;
+              license = licenses.asl20;
+              mainProgram = "omny";
+            };
+          }
+        );
       in
       {
+        checks = {
+          inherit omnyssh;
+          omnyssh-fmt = craneLib.cargoFmt { inherit pname version src; };
+          omnyssh-clippy = craneLib.cargoClippy (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--workspace --all-targets -- --deny warnings";
+            }
+          );
+          omnyssh-test = craneLib.cargoTest (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoExtraArgs = "--locked --workspace";
+            }
+          );
+        };
+
         packages = {
           default = omnyssh;
-          omnyssh = omnyssh;
+          inherit omnyssh;
         };
 
         apps.default = {
           type = "app";
           program = "${omnyssh}/bin/omny";
-          meta = omnyssh.meta;
+          inherit (omnyssh) meta;
         };
 
-        devShells.default = pkgs.mkShell {
-          inputsFrom = [ omnyssh ];
-          packages = with pkgs; [
-            rustc
-            cargo
-            rustfmt
-            clippy
-            rust-analyzer
+        devShells.default = craneLib.devShell {
+          checks = self.checks.${system};
+          packages = [
+            pkgs.rust-analyzer
           ];
 
           RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
         };
-      });
+      }
+    );
 }


### PR DESCRIPTION
## Problem

PR #11 added first-class Nix flake support for building, running, installing, and developing OmnySSH with Nix.

Since then, OmnySSH has been refactored into a Cargo workspace:

- `crates/omnyssh-core` contains the core SSH/config/metrics/update logic.
- `crates/omnyssh` contains the TUI application and the `omny` binary.
- The repository root `Cargo.toml` is now a virtual workspace manifest, not a package manifest.

The original flake still assumed that the root `Cargo.toml` had a `[package]` section. As a result, it no longer matched the current workspace layout and could fail while reading package metadata such as `name`, `version`, `description`, and `repository`.

## Solution

Migrate the flake from `rustPlatform.buildRustPackage` to [`crane`](https://github.com/ipetkov/crane), while keeping the public Nix interface from PR #11:

- `packages.default` / `packages.omnyssh` still build the installable `omny` binary.
- `apps.default` still supports `nix run`.
- `devShells.default` still provides a Rust development environment.
- The generated `doc/omny.1` man page is still installed into the package output.

The updated flake now understands the workspace layout explicitly:

- Reads shared workspace metadata from the root `Cargo.toml`.
- Reads application package metadata from `crates/omnyssh/Cargo.toml`.
- Builds the `omnyssh` package explicitly with `--package omnyssh`.
- Treats `omnyssh-core` as a workspace library crate and dependency, not as a separate installable binary.
- Adds `nix flake check` coverage for the package build, rustfmt, clippy, and workspace tests.

`crane` is used because it fits this workspace layout better than a single direct `buildRustPackage` derivation. It lets the flake clean the Cargo source with `cleanCargoSource`, build dependencies once with `buildDepsOnly`, reuse `cargoArtifacts` across the package build and checks, and keep `nix build` focused on producing the installable package while `nix flake check` handles workspace-wide validation.

This PR also updates the README Nix section for the current flake outputs and ignores the local `/result` symlink created by `nix build`.

## Test plan

Cargo workflow:

- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`

Nix workflow:

- [x] `nix flake check --show-trace`
- [x] `nix build .#omnyssh --print-build-logs`
- [x] `./result/bin/omny --version`
- [x] `nix run .# -- --version`
- [x] `nix flake show --all-systems`
- [x] Verified the package output contains:
  - `result/bin/omny`
  - `result/share/man/man1/omny.1.gz`

## Checklist

- [x] All Cargo tests pass (`cargo test`)
- [x] No Cargo clippy warnings (`cargo clippy -- -D warnings`)
- [x] Cargo formatting is valid (`cargo fmt --check`)
- [x] Nix flake checks pass (`nix flake check --show-trace`)
- [x] Nix package builds (`nix build .#omnyssh --print-build-logs`)
- [x] Nix app entry point works (`nix run .# -- --version`)
- [x] Relevant tests added — N/A, build tooling change
- [x] CHANGELOG entry added — left out for now because this restores Nix build support after the workspace refactor and does not change runtime application behavior
- [x] README updated for the user-facing flake changes

## Files changed

- `flake.nix`
  - Adds crane.
  - Migrates the package build to `craneLib.buildPackage`.
  - Reads workspace metadata from the root `Cargo.toml`.
  - Reads application package metadata from `crates/omnyssh/Cargo.toml`.
  - Builds the `omnyssh` workspace package explicitly.
  - Reuses dependency artifacts across the package build and checks.
  - Installs the generated man page.
  - Adds package, app, check, and dev shell outputs.

- `flake.lock`
  - Updates locked revisions after adding `crane`.

- `.gitignore`
  - Ignores the local `/result` symlink created by `nix build`.

- `README.md`
  - Updates the Nix flakes section for the current outputs.
  - Documents `nix flake check` as the validation command.