### PR TITLE
Fix/docs roadmap and connect keybind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## 1.1.0 — 2026-06-10
 
+### Documentation
+- README "Development Roadmap" now lists the current `1.1.0` release (and `1.0.5`); it previously stopped at `1.0.4`.
+- Removed the dead `connect` keybinding from the `config.toml` example and the `[keybindings]` config struct. Enter-to-connect was always hard-coded, so the field never had any effect.
+
 ### Internal
 - **Repository converted to a cargo workspace; the engine now lives in its own crate**: The SSH engine, host/snippet/app configuration, metrics parsers, domain events, and the self-updater moved into the new `omnyssh-core` library crate (`crates/omnyssh-core`), which has no dependency on terminal-UI or CLI crates. The TUI application keeps the `omnyssh` package name and the `omny` binary (`crates/omnyssh`) and consumes the core as a regular dependency. This prepares the architecture for additional frontends (e.g. a GUI) without duplicating the engine.
   - The event bus is split: background tasks emit `CoreEvent` values; the TUI wraps them into its own `AppEvent` stream alongside input events.

--- a/README.md
+++ b/README.md
@@ -299,7 +299,6 @@ theme = "default"              # default | dracula | nord | gruvbox
 [keybindings]
 quit         = "q"
 search       = "/"
-connect      = "Enter"
 dashboard    = "F1"
 file_manager = "F2"
 snippets     = "F3"
@@ -371,7 +370,9 @@ Set the theme in `config.toml`, or pass `--theme` once — it is written back to
 | `0.3.0` | 3 | Snippets & quick-execute |
 | `0.4.0` | 4 | SFTP file manager |
 | `0.5.0` | 5 | Multi-session tabs & split-view |
-| **`1.0.4`** | **6** | **Polish, themes, configurable keybindings — current** ✅ |
+| `1.0.4` | 6 | Polish, themes, configurable keybindings |
+| `1.0.5` | 6 | Dead-code cleanup, docs.rs build fix |
+| **`1.1.0`** | **6** | **Cargo workspace — frontend-agnostic `omnyssh-core` crate — current** ✅ |
 
 ---
 

--- a/crates/omnyssh-core/src/config/app_config.rs
+++ b/crates/omnyssh-core/src/config/app_config.rs
@@ -97,7 +97,6 @@ impl Default for UiConfig {
 pub struct KeybindingsConfig {
     pub quit: String,
     pub search: String,
-    pub connect: String,
     pub dashboard: String,
     pub file_manager: String,
     pub snippets: String,
@@ -187,7 +186,6 @@ impl Default for KeybindingsConfig {
         Self {
             quit: String::from("q"),
             search: String::from("/"),
-            connect: String::from("Enter"),
             dashboard: String::from("F1"),
             file_manager: String::from("F2"),
             snippets: String::from("F3"),


### PR DESCRIPTION
- README "Development Roadmap" now lists the current `1.1.0` release (and `1.0.5`); it previously stopped at `1.0.4`.
- Removed the dead `connect` keybinding from the `config.toml` example and the `[keybindings]` config struct. Enter-to-connect was always hard-coded, so the field never had any effect.
