### PR TITLE
Cleanup/remove deep probe remnants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
   - Keybinding parsing (config strings → key codes) and PTY key-to-bytes translation moved from the engine into the TUI crate; the core PTY API accepts raw bytes only.
   - Removed the unused `nucleo` dependency.
   - No user-facing changes: behavior, appearance, the binary name, and install paths are unchanged.
+- **Removed leftover Alerts/Deep Probe remnants**: Deleted the unused `[smart_context]` config (`SmartContextConfig` was parsed but never read) and reworded stale "Deep Probe" comments left after the subsystem was removed in 1.0.5. No user-facing change — existing config files containing a `[smart_context]` section still load, as the section is ignored.
 
 ---
 

--- a/crates/omnyssh-core/src/config/app_config.rs
+++ b/crates/omnyssh-core/src/config/app_config.rs
@@ -9,7 +9,6 @@ pub struct AppConfig {
     pub general: GeneralConfig,
     pub ui: UiConfig,
     pub keybindings: KeybindingsConfig,
-    pub smart_context: SmartContextConfig,
     pub auto_key_setup: AutoKeySetupConfig,
     pub update: UpdateConfig,
 }
@@ -107,25 +106,6 @@ pub struct KeybindingsConfig {
     /// Key to cycle terminal tabs / split panes.
     /// Default: `"Tab"`.
     pub next_tab: String,
-}
-
-/// Smart Server Context configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
-pub struct SmartContextConfig {
-    /// Enable automatic service discovery and monitoring.
-    pub enabled: bool,
-    /// Seconds between deep probe scans (set to 0 to disable periodic scans).
-    pub scan_interval: u64,
-}
-
-impl Default for SmartContextConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            scan_interval: 300, // 5 minutes
-        }
-    }
 }
 
 /// Auto SSH Key Setup configuration.

--- a/crates/omnyssh-core/src/ssh/discovery.rs
+++ b/crates/omnyssh-core/src/ssh/discovery.rs
@@ -1,11 +1,9 @@
 //! Service discovery orchestrator.
 //!
-//! Coordinates Quick Scan and Deep Probe operations to detect and monitor
-//! services on remote servers.
+//! Runs a Quick Scan to detect services on remote servers.
 //!
 //! Architecture:
 //! - Quick Scan runs once per connection, discovers which services exist
-//! - Deep Probe runs periodically to collect detailed metrics
 //! - All operations are async and use the existing SSH session
 //! - Results are sent via CoreEvent to the main loop
 

--- a/crates/omnyssh-core/src/ssh/services/docker.rs
+++ b/crates/omnyssh-core/src/ssh/services/docker.rs
@@ -23,7 +23,7 @@ impl ServiceProvider for DockerProvider {
     }
 
     /// Extract basic metrics from Quick Scan docker ps output.
-    /// This allows us to show container count immediately without waiting for Deep Probe.
+    /// This allows us to show container count immediately.
     fn quick_metrics(&self, probe_output: &ProbeOutput) -> Vec<super::ServiceMetric> {
         let mut metrics = Vec::new();
 

--- a/crates/omnyssh/src/ui/card.rs
+++ b/crates/omnyssh/src/ui/card.rs
@@ -410,7 +410,7 @@ fn service_info(service: &DetectedService) -> String {
         ServiceKind::Docker => {
             // Show detailed container breakdown: "4 running, 2 stopped, 1 restarting"
             if service.metrics.is_empty() {
-                return String::new(); // Deep Probe hasn't run yet
+                return String::new(); // no metrics yet
             }
 
             let mut running = 0i64;


### PR DESCRIPTION
- **Removed leftover Alerts/Deep Probe remnants**: Deleted the unused `[smart_context]` config (`SmartContextConfig` was parsed but never read) and reworded stale "Deep Probe" comments left after the subsystem was removed in 1.0.5. No user-facing change — existing config files containing a `[smart_context]` section still load, as the section is ignored.