### PR TITLE
Docs/document auto key setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 ## 1.1.0 — 2026-06-10
 
 ### Documentation
+- Documented the Auto SSH Key Setup feature (`Shift+K`): added a README Features entry, a Quick Start key reference, and a Help popup shortcut. The feature already existed but was undiscoverable.
 - README "Development Roadmap" now lists the current `1.1.0` release (and `1.0.5`); it previously stopped at `1.0.4`.
 - Removed the dead `connect` keybinding from the `config.toml` example and the `[keybindings]` config struct. Enter-to-connect was always hard-coded, so the field never had any effect.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Split-panel SFTP browser (local ↔ remote) with progress bars, multi-selection,
 ### ⚡ **Command Snippets**
 Save frequently-used commands and execute them on any server with one keypress. Broadcast a command to multiple hosts simultaneously.
 
+### 🔐 **Auto SSH Key Setup**
+Press `Shift+K` on a password-based host to generate an Ed25519 key, install it in the server's `authorized_keys`, and switch the host to key authentication. After verifying the key works, it can disable password login on the server — with an automatic `sshd_config` backup and rollback if anything fails.
+
 ### 🖥️ **Multi-Session Terminal**
 PTY tabs and split-view for working on several servers at once. Switch between hosts without leaving the app.
 
@@ -236,6 +239,7 @@ and `aarch64-darwin`.
    - `3` — Snippets (saved commands)
    - `4` — Terminal (multi-session)
    - `/` — Fuzzy search
+   - `Shift+K` — Set up SSH key auth on the selected host
    - `?` — Help popup
 
 ---

--- a/crates/omnyssh/src/ui/popup.rs
+++ b/crates/omnyssh/src/ui/popup.rs
@@ -147,6 +147,10 @@ pub fn render_help(frame: &mut Frame, theme: &Theme) {
         Span::styled("        Quick exec", desc_style),
     ]));
     col1_lines.push(Line::from(vec![
+        Span::styled("  K", key_style),
+        Span::styled("        Setup SSH key", desc_style),
+    ]));
+    col1_lines.push(Line::from(vec![
         Span::styled("  hjkl", key_style),
         Span::styled("    Navigate", desc_style),
     ]));


### PR DESCRIPTION
- Documented the Auto SSH Key Setup feature (`Shift+K`): added a README Features entry, a Quick Start key reference, and a Help popup shortcut. The feature already existed but was undiscoverable.