### PR TITLE
fix: fix shortcut issue and file manager user experience enhance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ---
 
+## Unreleased
+
+### Features
+- **File manager hidden-file toggle (`.`)**: show or hide dot-prefixed entries (hidden by default). The `..` parent entry is always shown.
+- **Nerd Font file icons in the file manager**: per-type glyphs replace the `[DIR]`/`[   ]` markers. Requires a Nerd Font — without one the glyphs render as empty boxes.
+
+### Changed
+- **Terminal next-tab moved from `Tab` to `Ctrl+N`**, freeing `Tab` for the shell's own completion inside the embedded terminal.
+- **File manager `h`/`Left` now navigates to the parent directory** (previously moved the cursor up), matching `ranger`/`lf`/`nnn`/`vifm`. Returning to a parent places the cursor on the directory just left.
+
+---
+
 ## 1.1.0 — 2026-06-10
 
 ### Documentation

--- a/crates/omnyssh-core/src/config/app_config.rs
+++ b/crates/omnyssh-core/src/config/app_config.rs
@@ -104,7 +104,7 @@ pub struct KeybindingsConfig {
     /// Default: `"Tab"`.
     pub next_screen: String,
     /// Key to cycle terminal tabs / split panes.
-    /// Default: `"Tab"`.
+    /// Default: `"Ctrl+N"`.
     pub next_tab: String,
 }
 
@@ -170,7 +170,7 @@ impl Default for KeybindingsConfig {
             file_manager: String::from("F2"),
             snippets: String::from("F3"),
             next_screen: String::from("Tab"),
-            next_tab: String::from("Tab"),
+            next_tab: String::from("Ctrl+N"),
         }
     }
 }

--- a/crates/omnyssh/src/app/action.rs
+++ b/crates/omnyssh/src/app/action.rs
@@ -120,6 +120,8 @@ pub enum AppAction {
     FmConfirmDelete,
     /// Open the new-directory popup (n).
     FmOpenMkDir,
+    /// Toggle visibility of hidden (dot-prefixed) entries in the active panel (`.`).
+    FmToggleHidden,
     /// User confirmed the new directory name.
     FmConfirmMkDir(String),
     /// Open the rename popup for the cursor item (R).

--- a/crates/omnyssh/src/app/actions.rs
+++ b/crates/omnyssh/src/app/actions.rs
@@ -455,6 +455,12 @@ impl App {
                 self.fm_parent_dir().await;
             }
 
+            AppAction::FmToggleHidden => {
+                let panel = self.active_fm_panel_mut();
+                panel.show_hidden = !panel.show_hidden;
+                panel.apply_hidden_filter();
+            }
+
             AppAction::FmMarkFile => {
                 let panel = self.active_fm_panel_mut();
                 if let Some(entry) = panel.cursor_entry() {

--- a/crates/omnyssh/src/app/file_manager.rs
+++ b/crates/omnyssh/src/app/file_manager.rs
@@ -903,10 +903,7 @@ mod tests {
 
     #[test]
     fn dotdot_always_visible_regardless_of_toggle() {
-        let mut p = panel_with_raw(vec![
-            entry("..", "/parent"),
-            entry(".bashrc", "/.bashrc"),
-        ]);
+        let mut p = panel_with_raw(vec![entry("..", "/parent"), entry(".bashrc", "/.bashrc")]);
         // show_hidden = false: .. must still be present (it's not a user
         // file, it's the parent marker).
         p.show_hidden = false;

--- a/crates/omnyssh/src/app/file_manager.rs
+++ b/crates/omnyssh/src/app/file_manager.rs
@@ -35,7 +35,12 @@ pub struct FmClipboard {
 pub struct FilePanelView {
     /// Current working directory being displayed.
     pub cwd: String,
-    /// Directory entries as returned by the last listing.
+    /// Unfiltered entries as returned by the last listing. Used to re-derive
+    /// `entries` when the user toggles hidden-file visibility, without
+    /// re-fetching from the filesystem or SFTP server.
+    pub raw_entries: Vec<FileEntry>,
+    /// Visible entries after applying the hidden-files filter. The render
+    /// code, cursor, and scroll all operate on this list.
     pub entries: Vec<FileEntry>,
     /// Absolute cursor index into `entries`.
     pub cursor: usize,
@@ -45,6 +50,16 @@ pub struct FilePanelView {
     pub scroll: std::cell::Cell<usize>,
     /// Set of `entry.path` values that are Space-marked.
     pub marked: HashSet<String>,
+    /// When set, the next listing for this panel will position the cursor on
+    /// the entry whose `path` matches this value, then clear it. Used to
+    /// remember the directory the user just left so navigating back places
+    /// the cursor on the child entry (matching the behaviour of `ranger`,
+    /// `lf`, `nnn`, `vifm`).
+    pub pending_focus_path: Option<String>,
+    /// When `false` (the default), entries whose name starts with `.` are
+    /// hidden. The synthetic `..` parent entry is always shown. Toggled with
+    /// the `.` key on the file panel.
+    pub show_hidden: bool,
 }
 
 impl FilePanelView {
@@ -79,6 +94,24 @@ impl FilePanelView {
     /// Move cursor up by one row, staying in bounds.
     pub fn select_prev(&mut self) {
         self.cursor = self.cursor.saturating_sub(1);
+    }
+
+    /// Rebuilds `entries` from `raw_entries` according to `show_hidden`.
+    /// The cursor is preserved by path — if the entry under the cursor is
+    /// still visible it stays put, otherwise the cursor falls back to 0.
+    /// `..` is always considered visible (it is the parent entry, not a
+    /// user-visible hidden file).
+    pub fn apply_hidden_filter(&mut self) {
+        let prev_path = self.entries.get(self.cursor).map(|e| e.path.clone());
+        self.entries = self
+            .raw_entries
+            .iter()
+            .filter(|e| self.show_hidden || e.name == ".." || !e.name.starts_with('.'))
+            .cloned()
+            .collect();
+        self.cursor = prev_path
+            .and_then(|p| self.entries.iter().position(|e| e.path == p))
+            .unwrap_or(0);
     }
 }
 
@@ -315,6 +348,14 @@ impl App {
             return;
         }
 
+        // Stash the directory we are leaving so the next listing positions
+        // the cursor on the matching child entry. When the cursor is on a
+        // regular child this is a no-op (the new listing won't contain the
+        // old cwd); when the cursor is on `..` it lands us back on the
+        // directory we just left.
+        let prev_cwd = self.active_fm_panel_ref().cwd.clone();
+        self.active_fm_panel_mut().pending_focus_path = Some(prev_cwd);
+
         if is_remote {
             if let Some(mgr) = &self.sftp_manager {
                 mgr.send(SftpCommand::ListDir(entry.path.clone()));
@@ -350,6 +391,10 @@ impl App {
         });
 
         let Some(parent) = parent else { return };
+
+        // Remember the directory we are leaving so the next listing lands the
+        // cursor on its entry in the parent's listing.
+        self.active_fm_panel_mut().pending_focus_path = Some(cwd);
 
         if is_remote {
             if let Some(mgr) = &self.sftp_manager {
@@ -659,5 +704,199 @@ mod tests {
         let mut p = panel(vec![entry("a", "/a")]);
         p.select_prev();
         assert_eq!(p.cursor, 0);
+    }
+
+    // --- pending_focus_path: cursor auto-positioning on parent navigation -
+
+    /// Replicates the logic the `CoreEvent::FileDirListed` /
+    /// `LocalDirListed` handlers apply when a new listing arrives: take the
+    /// pending focus path, find the entry whose `path` matches it, and set
+    /// the cursor to that entry's index (falling back to 0 if no match).
+    fn apply_listing(panel: &mut FilePanelView, entries: Vec<FileEntry>) {
+        panel.entries = entries;
+        panel.cursor = panel
+            .pending_focus_path
+            .take()
+            .and_then(|target| panel.entries.iter().position(|e| e.path == target))
+            .unwrap_or(0);
+    }
+
+    #[test]
+    fn pending_focus_positions_cursor_on_matching_entry() {
+        let entries = vec![
+            entry("..", "/"),
+            entry("alpha", "/alpha"),
+            entry("projects", "/projects"),
+            entry("zeta", "/zeta"),
+        ];
+        let mut p = panel(entries.clone());
+        // Simulate "we were in /projects and just went up".
+        p.pending_focus_path = Some("/projects".to_string());
+        apply_listing(&mut p, entries);
+        assert_eq!(p.cursor, 2, "cursor should land on the 'projects' entry");
+        assert!(p.pending_focus_path.is_none(), "field must be consumed");
+    }
+
+    #[test]
+    fn pending_focus_falls_back_to_zero_when_no_match() {
+        // The remembered path no longer exists in the new listing (e.g. it
+        // was renamed or deleted). Cursor must default to 0 and the field
+        // must still be cleared.
+        let entries = vec![entry("..", "/"), entry("alpha", "/alpha")];
+        let mut p = panel(entries.clone());
+        p.pending_focus_path = Some("/vanished".to_string());
+        apply_listing(&mut p, entries);
+        assert_eq!(p.cursor, 0);
+        assert!(p.pending_focus_path.is_none());
+    }
+
+    #[test]
+    fn no_pending_focus_starts_cursor_at_zero() {
+        // A first-time listing (app start, host connect) has no focus path.
+        let mut p = panel(vec![]);
+        apply_listing(
+            &mut p,
+            vec![entry("..", "/"), entry("alpha", "/alpha")],
+        );
+        assert_eq!(p.cursor, 0);
+    }
+
+    // --- apply_hidden_filter: dotfile visibility toggle ------------------
+
+    /// Convenience: build a panel with both raw and visible entries the
+    /// same way the real listing handlers do.
+    fn panel_with_raw(raw: Vec<FileEntry>) -> FilePanelView {
+        let mut p = FilePanelView::default();
+        p.raw_entries = raw;
+        // The real listing handlers assign `raw_entries` then call
+        // `apply_hidden_filter()` to derive the visible list. Tests should
+        // see the same post-filter state, so we run the filter here too.
+        p.apply_hidden_filter();
+        p
+    }
+
+    fn visible_names(p: &FilePanelView) -> Vec<&str> {
+        p.entries.iter().map(|e| e.name.as_str()).collect()
+    }
+
+    #[test]
+    fn default_hides_dotfiles_but_keeps_dotdot() {
+        let p = panel_with_raw(vec![
+            entry("..", "/"),
+            entry(".bashrc", "/.bashrc"),
+            entry("alpha", "/alpha"),
+            entry(".config", "/.config"),
+            entry("zeta", "/zeta"),
+        ]);
+        // show_hidden defaults to false, so dotfiles must be filtered out
+        // and `..` must always remain visible.
+        assert_eq!(
+            visible_names(&p),
+            vec!["..", "alpha", "zeta"],
+            "dotfiles hidden by default, .. always visible"
+        );
+        assert!(!p.show_hidden);
+    }
+
+    #[test]
+    fn toggling_show_hidden_reveals_dotfiles() {
+        let mut p = panel_with_raw(vec![
+            entry("..", "/"),
+            entry(".bashrc", "/.bashrc"),
+            entry("alpha", "/alpha"),
+            entry(".config", "/.config"),
+        ]);
+        // First toggle: reveal everything.
+        p.show_hidden = true;
+        p.apply_hidden_filter();
+        assert_eq!(
+            visible_names(&p),
+            vec!["..", ".bashrc", "alpha", ".config"],
+            "all entries visible when show_hidden = true"
+        );
+        // Second toggle: hide them again, restoring the original view.
+        p.show_hidden = false;
+        p.apply_hidden_filter();
+        assert_eq!(visible_names(&p), vec!["..", "alpha"]);
+    }
+
+    #[test]
+    fn cursor_preserved_by_path_when_toggling() {
+        // Start in the "show all" state: set up the panel so both raw
+        // and visible entries include the dotfile, with the cursor on
+        // `zeta`.
+        let raw = vec![
+            entry("..", "/"),
+            entry("alpha", "/alpha"),
+            entry(".hidden", "/.hidden"),
+            entry("zeta", "/zeta"),
+        ];
+        let mut p = FilePanelView {
+            raw_entries: raw.clone(),
+            entries: raw,
+            cursor: 3,
+            show_hidden: true,
+            ..FilePanelView::default()
+        };
+        // Toggle to "hide dotfiles". `..` and `zeta` must remain visible;
+        // the cursor must follow `zeta` (now at its new index, since
+        // `.hidden` and `alpha` shifted positions).
+        p.show_hidden = false;
+        p.apply_hidden_filter();
+        let zeta_idx = p
+            .entries
+            .iter()
+            .position(|e| e.name == "zeta")
+            .expect("zeta must still be in entries after toggle");
+        assert_eq!(p.cursor, zeta_idx, "cursor stays on zeta after hide");
+        // Toggle back to "show all" — cursor must still be on `zeta`.
+        p.show_hidden = true;
+        p.apply_hidden_filter();
+        let zeta_idx = p.entries.iter().position(|e| e.name == "zeta").unwrap();
+        assert_eq!(p.cursor, zeta_idx);
+    }
+
+    #[test]
+    fn cursor_falls_back_to_zero_when_cursor_path_is_filtered_out() {
+        // Cursor is on the dotfile entry; toggling to "hide" must move
+        // the cursor to a still-visible entry (here, `..` at index 0).
+        let raw = vec![
+            entry("..", "/"),
+            entry("alpha", "/alpha"),
+            entry(".hidden", "/.hidden"),
+            entry("zeta", "/zeta"),
+        ];
+        let mut p = FilePanelView {
+            raw_entries: raw.clone(),
+            entries: raw,
+            cursor: 2, // on `.hidden`
+            show_hidden: true,
+            ..FilePanelView::default()
+        };
+        p.show_hidden = false;
+        p.apply_hidden_filter();
+        // `.hidden` is filtered out, so cursor must fall back to 0.
+        assert_eq!(p.cursor, 0);
+        assert_eq!(p.entries[0].name, "..");
+    }
+
+    #[test]
+    fn dotdot_always_visible_regardless_of_toggle() {
+        let mut p = panel_with_raw(vec![
+            entry("..", "/parent"),
+            entry(".bashrc", "/.bashrc"),
+        ]);
+        // show_hidden = false: .. must still be present (it's not a user
+        // file, it's the parent marker).
+        p.show_hidden = false;
+        p.apply_hidden_filter();
+        assert!(
+            p.entries.iter().any(|e| e.name == ".."),
+            ".. must remain visible when show_hidden = false"
+        );
+        // show_hidden = true: .. is still there.
+        p.show_hidden = true;
+        p.apply_hidden_filter();
+        assert!(p.entries.iter().any(|e| e.name == ".."));
     }
 }

--- a/crates/omnyssh/src/app/file_manager.rs
+++ b/crates/omnyssh/src/app/file_manager.rs
@@ -112,6 +112,28 @@ impl FilePanelView {
         self.cursor = prev_path
             .and_then(|p| self.entries.iter().position(|e| e.path == p))
             .unwrap_or(0);
+        // Drop marks on entries that are no longer visible so a hidden file
+        // can't be silently included in a later delete/copy.
+        let visible = &self.entries;
+        self.marked.retain(|p| visible.iter().any(|e| &e.path == p));
+    }
+
+    /// Applies a fresh directory listing: stores `raw`, derives the visible
+    /// `entries` via the hidden-files filter, then positions the cursor on
+    /// `pending_focus_path` (the entry just left) if it is still visible.
+    /// Scroll and marks are reset. The cursor is set *after* filtering so the
+    /// filter cannot reset it. Both the core-event handlers and the tests go
+    /// through this method, so they exercise the same code path.
+    pub fn apply_listing(&mut self, raw: Vec<FileEntry>) {
+        self.raw_entries = raw;
+        self.apply_hidden_filter();
+        self.cursor = self
+            .pending_focus_path
+            .take()
+            .and_then(|target| self.entries.iter().position(|e| e.path == target))
+            .unwrap_or(0);
+        self.scroll.set(0);
+        self.marked.clear();
     }
 }
 
@@ -708,19 +730,6 @@ mod tests {
 
     // --- pending_focus_path: cursor auto-positioning on parent navigation -
 
-    /// Replicates the logic the `CoreEvent::FileDirListed` /
-    /// `LocalDirListed` handlers apply when a new listing arrives: take the
-    /// pending focus path, find the entry whose `path` matches it, and set
-    /// the cursor to that entry's index (falling back to 0 if no match).
-    fn apply_listing(panel: &mut FilePanelView, entries: Vec<FileEntry>) {
-        panel.entries = entries;
-        panel.cursor = panel
-            .pending_focus_path
-            .take()
-            .and_then(|target| panel.entries.iter().position(|e| e.path == target))
-            .unwrap_or(0);
-    }
-
     #[test]
     fn pending_focus_positions_cursor_on_matching_entry() {
         let entries = vec![
@@ -732,7 +741,7 @@ mod tests {
         let mut p = panel(entries.clone());
         // Simulate "we were in /projects and just went up".
         p.pending_focus_path = Some("/projects".to_string());
-        apply_listing(&mut p, entries);
+        p.apply_listing(entries);
         assert_eq!(p.cursor, 2, "cursor should land on the 'projects' entry");
         assert!(p.pending_focus_path.is_none(), "field must be consumed");
     }
@@ -745,19 +754,31 @@ mod tests {
         let entries = vec![entry("..", "/"), entry("alpha", "/alpha")];
         let mut p = panel(entries.clone());
         p.pending_focus_path = Some("/vanished".to_string());
-        apply_listing(&mut p, entries);
+        p.apply_listing(entries);
         assert_eq!(p.cursor, 0);
         assert!(p.pending_focus_path.is_none());
+    }
+
+    #[test]
+    fn pending_focus_survives_hidden_filter() {
+        // Regression: the listing must place the cursor on the focus target
+        // *after* the hidden-files filter runs. With show_hidden = false the
+        // dotfile is filtered out, but the visible target must still be found.
+        let mut p = FilePanelView::default();
+        p.pending_focus_path = Some("/home/projects".to_string());
+        p.apply_listing(vec![
+            entry("..", "/home"),
+            entry(".cache", "/home/.cache"),
+            entry("projects", "/home/projects"),
+        ]);
+        assert_eq!(p.entries[p.cursor].name, "projects");
     }
 
     #[test]
     fn no_pending_focus_starts_cursor_at_zero() {
         // A first-time listing (app start, host connect) has no focus path.
         let mut p = panel(vec![]);
-        apply_listing(
-            &mut p,
-            vec![entry("..", "/"), entry("alpha", "/alpha")],
-        );
+        p.apply_listing(vec![entry("..", "/"), entry("alpha", "/alpha")]);
         assert_eq!(p.cursor, 0);
     }
 
@@ -898,5 +919,26 @@ mod tests {
         p.show_hidden = true;
         p.apply_hidden_filter();
         assert!(p.entries.iter().any(|e| e.name == ".."));
+    }
+
+    #[test]
+    fn hiding_drops_marks_on_now_hidden_entries() {
+        let mut p = FilePanelView {
+            show_hidden: true,
+            ..FilePanelView::default()
+        };
+        p.apply_listing(vec![
+            entry("..", "/"),
+            entry(".secret", "/.secret"),
+            entry("visible", "/visible"),
+        ]);
+        p.marked.insert("/.secret".to_string());
+        p.marked.insert("/visible".to_string());
+        // Hiding dotfiles must drop the mark on the now-invisible .secret so
+        // it can't be deleted/copied blind; the visible mark stays.
+        p.show_hidden = false;
+        p.apply_hidden_filter();
+        assert!(!p.marked.contains("/.secret"));
+        assert!(p.marked.contains("/visible"));
     }
 }

--- a/crates/omnyssh/src/app/mod.rs
+++ b/crates/omnyssh/src/app/mod.rs
@@ -889,8 +889,19 @@ impl App {
             CoreEvent::FileDirListed { path, entries } => {
                 let rp = &mut self.view.file_manager.remote;
                 rp.cwd = path;
-                rp.entries = entries;
-                rp.cursor = 0;
+                // Stash the full listing, then derive the visible list
+                // according to the panel's hidden-files preference.
+                rp.raw_entries = entries;
+                // If the navigation initiator stashed a child path we just
+                // left, land the cursor on its entry in the new listing.
+                rp.cursor = rp
+                    .pending_focus_path
+                    .take()
+                    .and_then(|target| {
+                        rp.raw_entries.iter().position(|e| e.path == target)
+                    })
+                    .unwrap_or(0);
+                rp.apply_hidden_filter();
                 rp.scroll.set(0);
                 rp.marked.clear();
                 self.request_preview_for_active();
@@ -899,8 +910,15 @@ impl App {
             CoreEvent::LocalDirListed { path, entries } => {
                 let lp = &mut self.view.file_manager.local;
                 lp.cwd = path;
-                lp.entries = entries;
-                lp.cursor = 0;
+                lp.raw_entries = entries;
+                lp.cursor = lp
+                    .pending_focus_path
+                    .take()
+                    .and_then(|target| {
+                        lp.raw_entries.iter().position(|e| e.path == target)
+                    })
+                    .unwrap_or(0);
+                lp.apply_hidden_filter();
                 lp.scroll.set(0);
                 lp.marked.clear();
                 self.request_preview_for_active();

--- a/crates/omnyssh/src/app/mod.rs
+++ b/crates/omnyssh/src/app/mod.rs
@@ -889,38 +889,14 @@ impl App {
             CoreEvent::FileDirListed { path, entries } => {
                 let rp = &mut self.view.file_manager.remote;
                 rp.cwd = path;
-                // Stash the full listing, then derive the visible list
-                // according to the panel's hidden-files preference.
-                rp.raw_entries = entries;
-                // If the navigation initiator stashed a child path we just
-                // left, land the cursor on its entry in the new listing.
-                rp.cursor = rp
-                    .pending_focus_path
-                    .take()
-                    .and_then(|target| {
-                        rp.raw_entries.iter().position(|e| e.path == target)
-                    })
-                    .unwrap_or(0);
-                rp.apply_hidden_filter();
-                rp.scroll.set(0);
-                rp.marked.clear();
+                rp.apply_listing(entries);
                 self.request_preview_for_active();
             }
 
             CoreEvent::LocalDirListed { path, entries } => {
                 let lp = &mut self.view.file_manager.local;
                 lp.cwd = path;
-                lp.raw_entries = entries;
-                lp.cursor = lp
-                    .pending_focus_path
-                    .take()
-                    .and_then(|target| {
-                        lp.raw_entries.iter().position(|e| e.path == target)
-                    })
-                    .unwrap_or(0);
-                lp.apply_hidden_filter();
-                lp.scroll.set(0);
-                lp.marked.clear();
+                lp.apply_listing(entries);
                 self.request_preview_for_active();
             }
 

--- a/crates/omnyssh/src/app/terminal.rs
+++ b/crates/omnyssh/src/app/terminal.rs
@@ -78,7 +78,8 @@ pub struct TerminalView {
     /// Host-picker popup for creating a new tab (Ctrl+T).
     pub host_picker: Option<TermHostPicker>,
     /// When `true`, the next digit key 1–9 jumps directly to that tab.
-    /// Activated by pressing Tab (which also cycles to the next tab).
+    /// Activated by the next-tab key (`Ctrl+N` by default, which also cycles
+    /// to the next tab).
     pub tab_select_mode: bool,
 }
 

--- a/crates/omnyssh/src/keybindings.rs
+++ b/crates/omnyssh/src/keybindings.rs
@@ -39,7 +39,7 @@ pub struct ParsedKeybindings {
     pub snippets: KeyCode,
     /// Key that cycles to the next screen / switches FM panels (default: `Tab`).
     pub next_screen: KeyBind,
-    /// Key that cycles terminal tabs / split panes (default: `Tab`).
+    /// Key that cycles terminal tabs / split panes (default: `Ctrl+N`).
     pub next_tab: KeyBind,
 }
 

--- a/crates/omnyssh/src/ui/file_manager.rs
+++ b/crates/omnyssh/src/ui/file_manager.rs
@@ -138,7 +138,7 @@ pub fn handle_input(key: KeyEvent, view: &mut ViewState) -> Option<AppAction> {
         KeyCode::Char('j') | KeyCode::Down => Some(AppAction::FmNavDown),
         KeyCode::Char('k') | KeyCode::Up => Some(AppAction::FmNavUp),
         KeyCode::Char('l') | KeyCode::Right | KeyCode::Enter => Some(AppAction::FmEnterDir),
-        KeyCode::Char('h') | KeyCode::Left => Some(AppAction::FmNavUp),
+        KeyCode::Char('h') | KeyCode::Left => Some(AppAction::FmParentDir),
         KeyCode::Backspace => Some(AppAction::FmParentDir),
         KeyCode::Char(' ') => Some(AppAction::FmMarkFile),
         KeyCode::Tab => Some(AppAction::FmSwitchPanel),
@@ -146,6 +146,7 @@ pub fn handle_input(key: KeyEvent, view: &mut ViewState) -> Option<AppAction> {
         KeyCode::Char('p') => Some(AppAction::FmPaste),
         KeyCode::Char('D') => Some(AppAction::FmOpenDeleteConfirm),
         KeyCode::Char('n') => Some(AppAction::FmOpenMkDir),
+        KeyCode::Char('.') => Some(AppAction::FmToggleHidden),
         KeyCode::Char('R') => Some(AppAction::FmOpenRename),
         KeyCode::Char('H') => Some(AppAction::FmOpenHostPicker),
         KeyCode::Esc => Some(AppAction::FmClosePopup),
@@ -222,6 +223,14 @@ fn render_hints_header(frame: &mut Frame, area: Rect, theme: &crate::ui::theme::
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(":Delete", Style::default().fg(theme.text_muted)),
+        Span::raw("  "),
+        Span::styled(
+            ".",
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(":Hidden", Style::default().fg(theme.text_muted)),
         Span::raw("  "),
         Span::styled(
             "Shift+H",
@@ -381,8 +390,9 @@ fn render_panel(
             let is_cursor = original_idx == cursor;
             let is_marked = panel.marked.contains(&entry.path);
 
-            // Icon.
-            let icon = if entry.is_dir { "[DIR]" } else { "[   ]" };
+            // Nerd-font icon. Renders as a single cell width; falls back to
+            // empty boxes if the user does not have a Nerd Font installed.
+            let icon = crate::utils::file_icons::icon_for(&entry.name, entry.is_dir);
             let icon_color = if entry.is_dir {
                 Color::Cyan
             } else {
@@ -392,8 +402,9 @@ fn render_panel(
             // Cursor indicator.
             let cursor_prefix = if is_cursor { "▶ " } else { "  " };
 
-            // Marked indicator.
-            let mark_str = if is_marked { "●" } else { " " };
+            // Marked indicator (with trailing space so the glyph doesn't
+            // touch the file icon and visually overlap with it).
+            let mark_str = if is_marked { "●  " } else { "   " };
 
             // Size string (right-aligned, skip for dirs and "..").
             let size_str = if entry.is_dir || entry.name == ".." {
@@ -402,9 +413,13 @@ fn render_panel(
                 format_size(entry.size)
             };
 
+            // Width budget: cursor(2) + mark(3, with trailing padding) +
+            // icon(1) + space(1) + name + space-before-size(1) + size.
+            // The nerd-font glyph occupies a single cell even though its
+            // codepoint is wide.
             let name_width = inner
                 .width
-                .saturating_sub(2 + 2 + 5 + 1 + size_str.len() as u16 + 1)
+                .saturating_sub(2 + 3 + 1 + 1 + 1 + size_str.len() as u16)
                 as usize;
             let name_display: String = if entry.name.chars().count() > name_width {
                 let truncated = entry

--- a/crates/omnyssh/src/ui/popup.rs
+++ b/crates/omnyssh/src/ui/popup.rs
@@ -215,6 +215,10 @@ pub fn render_help(frame: &mut Frame, theme: &Theme) {
         Span::styled("  H", key_style),
         Span::styled("        Connect", desc_style),
     ]));
+    col2_lines.push(Line::from(vec![
+        Span::styled("  .", key_style),
+        Span::styled("        Toggle hidden", desc_style),
+    ]));
     col2_lines.push(Line::from(""));
 
     col2_lines.push(Line::from(Span::styled(" SNIPPETS", section_style)));
@@ -257,8 +261,8 @@ pub fn render_help(frame: &mut Frame, theme: &Theme) {
         Span::styled("   Close tab", desc_style),
     ]));
     col3_lines.push(Line::from(vec![
-        Span::styled("  Tab", key_style),
-        Span::styled("      Next tab", desc_style),
+        Span::styled("  Ctrl+N", key_style),
+        Span::styled("   Next tab", desc_style),
     ]));
     col3_lines.push(Line::from(vec![
         Span::styled("  Ctrl+\\", key_style),

--- a/crates/omnyssh/src/ui/terminal.rs
+++ b/crates/omnyssh/src/ui/terminal.rs
@@ -189,9 +189,9 @@ fn render_tab_bar(
 
     // "[+]" hint for new tab + copy instruction.
     let hint = if tv.split.is_some() {
-        " Ctrl+T:new  Ctrl+W:close  Ctrl+H:switch-pane  Ctrl+\\ :split-v  Ctrl+]:split-h  │  Opt/Shift+Drag to select"
+        " Ctrl+T:new  Ctrl+W:close  Ctrl+N:next  Ctrl+H:switch-pane  Ctrl+\\ :split-v  Ctrl+]:split-h  │  Opt/Shift+Drag to select"
     } else {
-        " Ctrl+T:new  Ctrl+W:close  Ctrl+\\ :split-v  Ctrl+]:split-h  │  Opt/Shift+Drag to select"
+        " Ctrl+T:new  Ctrl+W:close  Ctrl+N:next  Ctrl+\\ :split-v  Ctrl+]:split-h  │  Opt/Shift+Drag to select"
     };
     spans.push(Span::styled(hint, Style::default().fg(theme.text_muted)));
 

--- a/crates/omnyssh/src/utils/file_icons.rs
+++ b/crates/omnyssh/src/utils/file_icons.rs
@@ -33,8 +33,8 @@ pub fn icon_for(name: &str, is_dir: bool) -> &'static str {
 fn icon_by_ext(ext: &str) -> &'static str {
     match ext {
         // ── text / markup / data ──────────────────────────────────────
-        "txt"  | "md" | "rst" | "log" | "json" | "yaml" | "yml"
-        | "toml" | "ini" | "conf" | "cfg" | "xml" | "proto" => FILE_TEXT_O,
+        "txt" | "md" | "rst" | "log" | "json" | "yaml" | "yml" | "toml" | "ini" | "conf"
+        | "cfg" | "xml" | "proto" => FILE_TEXT_O,
 
         "csv" | "tsv" => FILE_CSV,
 
@@ -42,30 +42,30 @@ fn icon_by_ext(ext: &str) -> &'static str {
         "sh" | "bash" | "zsh" | "fish" | "ps1" | "bat" => CONSOLE,
 
         // ── source code ───────────────────────────────────────────────
-        "rs"        => SETI_RUST,
-        "py"        => SETI_PYTHON,
+        "rs" => SETI_RUST,
+        "py" => SETI_PYTHON,
         "js" | "jsx" | "mjs" | "cjs" => SETI_JS,
         "ts" | "tsx" => SETI_TS,
-        "c"  | "h"  => SETI_C,
+        "c" | "h" => SETI_C,
         "cpp" | "hpp" | "cc" | "hh" => SETI_CPP,
         "java" | "jar" | "war" => SETI_JAVA,
         "kt" | "kts" => SETI_KOTLIN,
-        "go"        => SETI_GO,
-        "rb"        => SETI_RUBY,
-        "php"       => SETI_PHP,
-        "pl"        => SETI_PERL,
-        "lua"       => SETI_LUA,
-        "swift"     => SETI_SWIFT,
-        "scala"     => SETI_SCALA,
-        "dart"      => SETI_DART,
-        "hs"        => SETI_HASKELL,
+        "go" => SETI_GO,
+        "rb" => SETI_RUBY,
+        "php" => SETI_PHP,
+        "pl" => SETI_PERL,
+        "lua" => SETI_LUA,
+        "swift" => SETI_SWIFT,
+        "scala" => SETI_SCALA,
+        "dart" => SETI_DART,
+        "hs" => SETI_HASKELL,
         "ex" | "exs" => SETI_ELIXIR,
-        "erl"       => SETI_ERLANG,
-        "elm"       => SETI_ELM,
-        "r"         => SETI_RLANG,
-        "jl"        => SETI_JULIA,
-        "sql"       => SETI_DB,
-        "graphql"   => SETI_GRAPHQL,
+        "erl" => SETI_ERLANG,
+        "elm" => SETI_ELM,
+        "r" => SETI_RLANG,
+        "jl" => SETI_JULIA,
+        "sql" => SETI_DB,
+        "graphql" => SETI_GRAPHQL,
 
         // ── secrets / keys ────────────────────────────────────────────
         "lock" => LOCK,
@@ -73,28 +73,25 @@ fn icon_by_ext(ext: &str) -> &'static str {
 
         // ── web ───────────────────────────────────────────────────────
         "html" | "htm" => SETI_HTML,
-        "css"  | "scss" | "sass" | "less" => SETI_CSS,
-        "vue"  => SETI_VUE,
+        "css" | "scss" | "sass" | "less" => SETI_CSS,
+        "vue" => SETI_VUE,
         "svelte" => SETI_SVELTE,
 
         // ── images ────────────────────────────────────────────────────
-        "png" | "jpg" | "jpeg" | "gif" | "bmp" | "svg" | "webp"
-        | "ico" | "tif" | "tiff" | "eps" | "fig" => FILE_IMAGE_O,
+        "png" | "jpg" | "jpeg" | "gif" | "bmp" | "svg" | "webp" | "ico" | "tif" | "tiff"
+        | "eps" | "fig" => FILE_IMAGE_O,
 
         "ai" => SETI_ILLUSTRATOR,
 
         // ── video ─────────────────────────────────────────────────────
-        "mp4" | "mkv" | "mov" | "avi" | "webm" | "flv" | "wmv" | "m4v"
-            => FILE_VIDEO_O,
+        "mp4" | "mkv" | "mov" | "avi" | "webm" | "flv" | "wmv" | "m4v" => FILE_VIDEO_O,
 
         // ── audio ─────────────────────────────────────────────────────
-        "mp3" | "wav" | "flac" | "ogg" | "m4a" | "aac" | "opus"
-            => FILE_AUDIO_O,
+        "mp3" | "wav" | "flac" | "ogg" | "m4a" | "aac" | "opus" => FILE_AUDIO_O,
 
         // ── archives / packages ───────────────────────────────────────
-        "zip" | "tar" | "gz" | "bz2" | "xz" | "7z" | "rar" | "tgz"
-        | "tbz" | "txz" | "deb" | "rpm" | "apk" | "iso" | "dmg"
-            => FILE_ARCHIVE_O,
+        "zip" | "tar" | "gz" | "bz2" | "xz" | "7z" | "rar" | "tgz" | "tbz" | "txz" | "deb"
+        | "rpm" | "apk" | "iso" | "dmg" => FILE_ARCHIVE_O,
 
         // ── documents ─────────────────────────────────────────────────
         "pdf" => FILE_PDF_O,

--- a/crates/omnyssh/src/utils/file_icons.rs
+++ b/crates/omnyssh/src/utils/file_icons.rs
@@ -1,0 +1,206 @@
+//! Nerd-font file type icons for the File Manager screen.
+//!
+//! Maps a file or directory entry to a single-glyph icon from a Nerd Font
+//! (https://www.nerdfonts.com/). If the user does not have a Nerd Font
+//! installed the glyphs render as empty boxes — the file manager still
+//! works, it just looks plain. The README/install docs mention Nerd Font as
+//! a recommendation for the File Manager.
+//!
+//! Icon set: Font Awesome extension private-use area, which is bundled in
+//! every popular Nerd Font (Hack, FiraCode, Meslo, Iosevka, JetBrainsMono,
+//! …).
+
+/// Returns the Nerd Font icon glyph for a given file or directory name.
+///
+/// `is_dir` is honoured first so the caller can pass any entry; for `..` we
+/// return the open-folder glyph so the parent entry stays visually distinct.
+pub fn icon_for(name: &str, is_dir: bool) -> &'static str {
+    if is_dir {
+        return if name == ".." { DIR_OPEN } else { DIR_CLOSED };
+    }
+
+    let ext_lower: String = match name.rfind('.') {
+        // Hidden dotfiles like `.bashrc` have no extension — fall through
+        // to the generic glyph.
+        Some(0) => return GENERIC,
+        Some(idx) => name[idx + 1..].to_ascii_lowercase(),
+        None => return GENERIC,
+    };
+
+    icon_by_ext(&ext_lower)
+}
+
+fn icon_by_ext(ext: &str) -> &'static str {
+    match ext {
+        // ── text / markup / data ──────────────────────────────────────
+        "txt"  | "md" | "rst" | "log" | "json" | "yaml" | "yml"
+        | "toml" | "ini" | "conf" | "cfg" | "xml" | "proto" => FILE_TEXT_O,
+
+        "csv" | "tsv" => FILE_CSV,
+
+        // ── shell / scripts ───────────────────────────────────────────
+        "sh" | "bash" | "zsh" | "fish" | "ps1" | "bat" => CONSOLE,
+
+        // ── source code ───────────────────────────────────────────────
+        "rs"        => SETI_RUST,
+        "py"        => SETI_PYTHON,
+        "js" | "jsx" | "mjs" | "cjs" => SETI_JS,
+        "ts" | "tsx" => SETI_TS,
+        "c"  | "h"  => SETI_C,
+        "cpp" | "hpp" | "cc" | "hh" => SETI_CPP,
+        "java" | "jar" | "war" => SETI_JAVA,
+        "kt" | "kts" => SETI_KOTLIN,
+        "go"        => SETI_GO,
+        "rb"        => SETI_RUBY,
+        "php"       => SETI_PHP,
+        "pl"        => SETI_PERL,
+        "lua"       => SETI_LUA,
+        "swift"     => SETI_SWIFT,
+        "scala"     => SETI_SCALA,
+        "dart"      => SETI_DART,
+        "hs"        => SETI_HASKELL,
+        "ex" | "exs" => SETI_ELIXIR,
+        "erl"       => SETI_ERLANG,
+        "elm"       => SETI_ELM,
+        "r"         => SETI_RLANG,
+        "jl"        => SETI_JULIA,
+        "sql"       => SETI_DB,
+        "graphql"   => SETI_GRAPHQL,
+
+        // ── secrets / keys ────────────────────────────────────────────
+        "lock" => LOCK,
+        "pem" | "key" | "crt" | "cer" | "pub" => KEY,
+
+        // ── web ───────────────────────────────────────────────────────
+        "html" | "htm" => SETI_HTML,
+        "css"  | "scss" | "sass" | "less" => SETI_CSS,
+        "vue"  => SETI_VUE,
+        "svelte" => SETI_SVELTE,
+
+        // ── images ────────────────────────────────────────────────────
+        "png" | "jpg" | "jpeg" | "gif" | "bmp" | "svg" | "webp"
+        | "ico" | "tif" | "tiff" | "eps" | "fig" => FILE_IMAGE_O,
+
+        "ai" => SETI_ILLUSTRATOR,
+
+        // ── video ─────────────────────────────────────────────────────
+        "mp4" | "mkv" | "mov" | "avi" | "webm" | "flv" | "wmv" | "m4v"
+            => FILE_VIDEO_O,
+
+        // ── audio ─────────────────────────────────────────────────────
+        "mp3" | "wav" | "flac" | "ogg" | "m4a" | "aac" | "opus"
+            => FILE_AUDIO_O,
+
+        // ── archives / packages ───────────────────────────────────────
+        "zip" | "tar" | "gz" | "bz2" | "xz" | "7z" | "rar" | "tgz"
+        | "tbz" | "txz" | "deb" | "rpm" | "apk" | "iso" | "dmg"
+            => FILE_ARCHIVE_O,
+
+        // ── documents ─────────────────────────────────────────────────
+        "pdf" => FILE_PDF_O,
+        "doc" | "docx" | "odt" | "rtf" => FILE_WORD_O,
+        "xls" | "xlsx" | "ods" | "ppt" | "pptx" | "odp" => FILE_EXCEL_O,
+
+        // ── executables / libraries ───────────────────────────────────
+        "exe" | "msi" | "app" | "dll" | "so" | "dylib" | "bin" => ROCKET,
+
+        // ── fonts ─────────────────────────────────────────────────────
+        "ttf" | "otf" | "woff" | "woff2" | "eot" => FONT,
+
+        // ── everything else ───────────────────────────────────────────
+        _ => GENERIC,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Glyphs (Font Awesome private-use area)
+// ---------------------------------------------------------------------------
+
+const GENERIC: &str = "\u{f15b}"; //  nf-fa-file-o
+const FILE_TEXT_O: &str = "\u{f15c}"; //  nf-fa-file-text-o
+const FILE_CSV: &str = "\u{f1c3}"; //  nf-fa-file-csv-o
+const FILE_IMAGE_O: &str = "\u{f1c5}"; //  nf-fa-file-image-o
+const FILE_VIDEO_O: &str = "\u{f1c8}"; //  nf-fa-file-video-o
+const FILE_AUDIO_O: &str = "\u{f1c7}"; //  nf-fa-file-audio-o
+const FILE_ARCHIVE_O: &str = "\u{f1c6}"; //  nf-fa-file-archive-o
+const FILE_PDF_O: &str = "\u{f1c1}"; //  nf-fa-file-pdf-o
+const FILE_WORD_O: &str = "\u{f1c2}"; //  nf-fa-file-word-o
+const FILE_EXCEL_O: &str = "\u{f1c4}"; //  nf-fa-file-excel-o
+const DIR_CLOSED: &str = "\u{f07b}"; //  nf-fa-folder
+const DIR_OPEN: &str = "\u{f07c}"; //  nf-fa-folder-open
+const KEY: &str = "\u{f084}"; //  nf-fa-key
+const LOCK: &str = "\u{f023}"; //  nf-fa-lock
+const ROCKET: &str = "\u{f135}"; //  nf-fa-rocket
+const FONT: &str = "\u{f031}"; //  nf-fa-font
+const CONSOLE: &str = "\u{f489}"; //  nf-md-console
+
+// Seti-UI (also in every Nerd Font) — used for language-specific icons.
+const SETI_RUST: &str = "\u{e7a8}";
+const SETI_PYTHON: &str = "\u{e73c}";
+const SETI_JS: &str = "\u{e74e}";
+const SETI_TS: &str = "\u{e628}";
+const SETI_C: &str = "\u{e61e}";
+const SETI_CPP: &str = "\u{e61d}";
+const SETI_JAVA: &str = "\u{e738}";
+const SETI_KOTLIN: &str = "\u{e634}";
+const SETI_GO: &str = "\u{e626}";
+const SETI_RUBY: &str = "\u{e739}";
+const SETI_PHP: &str = "\u{e73d}";
+const SETI_PERL: &str = "\u{e67e}";
+const SETI_LUA: &str = "\u{e620}";
+const SETI_SWIFT: &str = "\u{e755}";
+const SETI_SCALA: &str = "\u{e737}";
+const SETI_DART: &str = "\u{e798}";
+const SETI_HASKELL: &str = "\u{e61f}";
+const SETI_ELIXIR: &str = "\u{e62d}";
+const SETI_ERLANG: &str = "\u{e62b}";
+const SETI_ELM: &str = "\u{e62c}";
+const SETI_RLANG: &str = "\u{e68a}";
+const SETI_JULIA: &str = "\u{e624}";
+const SETI_DB: &str = "\u{e706}";
+const SETI_GRAPHQL: &str = "\u{e662}";
+const SETI_HTML: &str = "\u{e736}";
+const SETI_CSS: &str = "\u{e749}";
+const SETI_VUE: &str = "\u{e6a0}";
+const SETI_SVELTE: &str = "\u{e6a1}";
+const SETI_ILLUSTRATOR: &str = "\u{e7b4}";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn directories_get_folder_glyph() {
+        assert_eq!(icon_for("projects", true), DIR_CLOSED);
+        assert_eq!(icon_for("..", true), DIR_OPEN);
+    }
+
+    #[test]
+    fn extension_lookup_is_case_insensitive() {
+        assert_eq!(icon_for("README.TXT", false), icon_for("readme.txt", false));
+        assert_eq!(icon_for("PHOTO.JPG", false), icon_for("photo.jpg", false));
+    }
+
+    #[test]
+    fn hidden_dotfiles_get_generic_glyph() {
+        assert_eq!(icon_for(".bashrc", false), GENERIC);
+        assert_eq!(icon_for(".profile", false), GENERIC);
+    }
+
+    #[test]
+    fn unknown_extension_falls_back_to_generic() {
+        assert_eq!(icon_for("weirdo.zzz", false), GENERIC);
+    }
+
+    #[test]
+    fn common_languages_resolve() {
+        assert!(!icon_for("main.rs", false).is_empty());
+        assert!(!icon_for("app.py", false).is_empty());
+        assert!(!icon_for("index.js", false).is_empty());
+    }
+
+    #[test]
+    fn no_extension_file_is_generic() {
+        assert_eq!(icon_for("Makefile", false), GENERIC);
+    }
+}

--- a/crates/omnyssh/src/utils/mod.rs
+++ b/crates/omnyssh/src/utils/mod.rs
@@ -1,3 +1,4 @@
 /// Cross-platform utility helpers.
+pub mod file_icons;
 pub mod mouse;
 pub mod paste;


### PR DESCRIPTION
1. fix: replace cycle terminal keybinding from tab to ctrl + n, then tab can be used to terminal auto completion
2. fix: file manager navigator h is not same as up to parent 
3. feature: use nerd-font icon in file manager 
4. feature: add . to toggle dotfile 