### PR TITLE
ci: bound the apt steps and give every job a timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   hygiene:
     name: Repo hygiene guard
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -27,6 +28,7 @@ jobs:
   build-and-test:
     name: Build & Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +77,7 @@ jobs:
   gui:
     name: GUI checks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -108,7 +111,14 @@ jobs:
       # installs more, but those are the bundler's (icons, AppImage) and this job only
       # compiles.
       - name: Install GUI build dependencies
+        timeout-minutes: 6
         run: |
+          # The runner image points apt at an Azure mirror that intermittently
+          # black-holes connections. apt then retries every repository for two
+          # minutes apiece: one run spent 36 minutes here before it was cancelled.
+          # Fail over to the next mirror in seconds instead.
+          printf 'Acquire::Retries "2";\nAcquire::http::Timeout "15";\nAcquire::https::Timeout "15";\n' \
+            | sudo tee /etc/apt/apt.conf.d/99-omnyssh-ci-timeouts > /dev/null
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev
 
@@ -138,6 +148,7 @@ jobs:
   tui-build-independence:
     name: TUI builds without the GUI toolchain
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,14 @@ jobs:
       # itself; gcc-aarch64-linux-gnu only supplies the ELF linker.
       - name: Install aarch64 cross linker
         if: matrix.target == 'aarch64-unknown-linux-musl'
+        timeout-minutes: 6
         run: |
+          # The runner image points apt at an Azure mirror that intermittently
+          # black-holes connections. apt then retries every repository for two
+          # minutes apiece: one run spent 36 minutes here before it was cancelled.
+          # Fail over to the next mirror in seconds instead.
+          printf 'Acquire::Retries "2";\nAcquire::http::Timeout "15";\nAcquire::https::Timeout "15";\n' \
+            | sudo tee /etc/apt/apt.conf.d/99-omnyssh-ci-timeouts > /dev/null
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
@@ -222,7 +229,14 @@ jobs:
       # the AppImage). Only Linux needs them; macOS/Windows use system webviews.
       - name: Install Linux bundle dependencies
         if: runner.os == 'Linux'
+        timeout-minutes: 6
         run: |
+          # The runner image points apt at an Azure mirror that intermittently
+          # black-holes connections. apt then retries every repository for two
+          # minutes apiece: one run spent 36 minutes here before it was cancelled.
+          # Fail over to the next mirror in seconds instead.
+          printf 'Acquire::Retries "2";\nAcquire::http::Timeout "15";\nAcquire::https::Timeout "15";\n' \
+            | sudo tee /etc/apt/apt.conf.d/99-omnyssh-ci-timeouts > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \


### PR DESCRIPTION
The post-merge run on `main` spent **36 minutes** in "Install GUI build dependencies" before it was cancelled. The same job takes 4m45s–7m40s normally, and every other job in that run finished in under 2.5 minutes — so this is one stalled mirror, not slow CI.

**What happened.** The runner image points apt at `azure.archive.ubuntu.com`, which black-holed connections on that runner. apt's defaults are `Acquire::http::Timeout` 120s with several retries per repository, so it worked through every repo twice over before falling back to `archive.ubuntu.com` — which then succeeded. Nothing bounded any of it: neither workflow sets `timeout-minutes` on a single job or step, so GitHub's six-hour default was the only limit.

**Fix.**

- Drop an `apt.conf.d` snippet before each `apt-get update` — `Acquire::Retries 2`, HTTP/HTTPS timeouts 15s — so a dead mirror fails over in seconds instead of minutes. The happy path is unchanged; the Azure mirror is co-located with the runners and stays the first choice.
- `timeout-minutes: 6` on the three apt steps (`ci.yml` GUI deps, `release.yml` cross linker and Linux bundle deps).
- `timeout-minutes` on every `ci.yml` job — 10 for the hygiene guard, 30 for the rest, which is well clear of a cold-cache build but ends a stall in minutes rather than hours.

No step's behaviour changes when the network is healthy.